### PR TITLE
Optimization in alignment.

### DIFF
--- a/src/AbismalAlign.hpp
+++ b/src/AbismalAlign.hpp
@@ -222,6 +222,12 @@ get_best_score(const std::vector<score_t> &table,
   return *best_cell_itr;
 }
 
+// ADS: it seems like with g++-13, on macos ventura on intel hardware
+// the dynamic vectorized optimization of -O3 might be too aggressive
+// and makes this function have strange behavior. Placing this pragma
+// here helps, and below we restore it to the `-O3` default.
+#pragma GCC optimize("vect-cost-model=very-cheap")
+
 template <score_t (*scr_fun)(const uint8_t, const uint8_t),
           class T, class QueryConstItr>
 void
@@ -290,6 +296,7 @@ from_left(T left_itr, T target, const T target_end, U traceback) {
     ++traceback; ++left_itr; ++target;
   }
 }
+#pragma GCC optimize("vect-cost-model=dynamic")
 
 
 inline void


### PR DESCRIPTION
This should fix a bug affecting certain reads on macOS Ventura, intel and gcc-13 with O3 optimization.

I added directives for compiler to do less aggressive vector optimization around the tight loops that iterate in parallel while doing alignment in a band. Specifically, the `from_diag`, `from_above` and `from_left`, both those with and without traceback. I was able to alter only a subset of those 6 functions and make certain test cases work, but the only way the entire regression test file in `dnmtools` would pass is with all 6 functions allowing at not more than the `very-cheap` option for dynamic vectorization. It seems like a second directive can turn the optimization back on for functions below in the file.