### PR TITLE
Direct BAM format output

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -16,8 +16,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+    - name: Update packages
+      run: sudo apt-get update
     - name: Install autotools
       run: sudo apt-get install -y autoconf automake libtool
+    - name: Install dependencies
+      run: sudo apt-get install -y libhts-dev
     - name: Generate configure script
       run: ./autogen.sh
     - name: configure

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/smithlab_cpp"]
 	path = src/smithlab_cpp
 	url = ../smithlab_cpp.git
+[submodule "src/bamxx"]
+	path = src/bamxx
+	url = git@github.com:smithlabcode/bamxx.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -53,7 +53,9 @@ libabismal_a_SOURCES += \
 	src/AbismalAlign.hpp \
 	src/AbismalIndex.hpp \
 	src/dna_four_bit_bisulfite.hpp \
-	src/popcnt.hpp
+	src/popcnt.hpp \
+	src/abismal_cigar_utils.hpp \
+	src/bamxx/bamxx.hpp
 
 LDADD = libabismal.a src/smithlab_cpp/libsmithlab_cpp.a
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 SUBDIRS := src/smithlab_cpp
 install installdirs: SUBDIRS := $(filter-out src/smithlab_cpp, $(SUBDIRS))
-AM_CPPFLAGS = -I $(top_srcdir)/src/smithlab_cpp
+AM_CPPFLAGS = -I $(top_srcdir)/src/smithlab_cpp -I $(top_srcdir)/src/bamxx
 
 CXXFLAGS = -Wall -O3 $(OPENMP_CXXFLAGS) # default has optimization on
 

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,17 @@ AC_PROG_RANLIB
 
 AC_CONFIG_SUBDIRS([src/smithlab_cpp])
 
+dnl check for HTSLib if requested
+hts_fail_msg="
+Failed to locate HTSLib on your system. Please use the LDFLAGS and
+CPPFLAGS variables to specify the directories where the HTSLib library
+and headers can be found.
+"
+
+dnl check for required libraries
+AC_SEARCH_LIBS([hts_version], [hts], [], [AC_MSG_FAILURE([$hts_fail_msg])])
+
+
 dnl OpenMP happens here
 AC_OPENMP([C++])
 AS_VAR_IF(OPENMP_CXXFLAGS, [], [

--- a/configure.ac
+++ b/configure.ac
@@ -54,10 +54,6 @@ dnl now we get setup for the right OpenMP flags
 ADS_OPENMP([], [AC_MSG_FAILURE([OpenMP must be installed to build abismal])])
 ])dnl end of OpenMP stuff
 
-dnl check for the Zlib library
-AC_CHECK_LIB([z], [zlibVersion], [],
-  [AC_MSG_FAILURE([Zlib must be installed to build abismal])], [])
-
 AC_CONFIG_FILES([
 Makefile
 ])

--- a/src/AbismalAlign.hpp
+++ b/src/AbismalAlign.hpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2019 Andrew D. Smith
+/* Copyright (C) 2019-2023 Andrew D. Smith
  *
  * Authors: Andrew D. Smith
  *
@@ -18,13 +18,15 @@
 #ifndef ABISMAL_ALIGN_HPP
 #define ABISMAL_ALIGN_HPP
 
-#include <string>
-#include <vector>
+#include <htslib/sam.h>
+
 #include <algorithm>
 #include <array>
-#include <cstdint> // for uint8_t and friends
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <vector>
 
-#include "cigar_utils.hpp"
 #include "dna_four_bit.hpp"
 
 // AbismalAlign class has a templated function for the comparison
@@ -33,6 +35,29 @@
 // subsequence.
 typedef int16_t score_t;
 typedef genome_four_bit_itr genome_iterator;
+typedef std::vector<uint32_t> bam_cigar_t;
+
+static inline score_t
+count_deletions(const bam_cigar_t &cigar) {
+  score_t ans = 0;
+  const auto lim(std::end(cigar));
+  for (auto it(begin(cigar)); it != lim; ++it) {
+    const auto x = *it;
+    if (bam_cigar_op(x) == BAM_CDEL) ans += bam_cigar_oplen(x);
+  }
+  return ans;
+}
+
+static inline score_t
+count_insertions(const bam_cigar_t &cigar) {
+  score_t ans = 0;
+  const auto lim(std::end(cigar));
+  for (auto it(begin(cigar)); it != lim; ++it) {
+    const auto x = *it;
+    if (bam_cigar_op(x) == BAM_CINS) ans += bam_cigar_oplen(x);
+  }
+  return ans;
+}
 
 // A specific namespace for simple match/mismatch scoring system and a
 // 1 -1 -1 scoring scheme for edit distance.
@@ -43,36 +68,16 @@ namespace simple_aln {
   static const std::array<score_t, 2> score_lookup = {match, mismatch};
 
   inline score_t default_score(const uint32_t len, const score_t diffs) {
-    return match*(len - diffs) + mismatch*diffs;
-  }
-  static score_t
-  count_deletions(const std::string &cigar) {
-    score_t ans = 0;
-    const auto lim = std::end(cigar);
-    for (auto it(begin(cigar)); it != lim; ++it) {
-      ans += (extract_op_count(it, lim)) * (*it == 'D');
-    }
-    return ans;
+    return match * (len - diffs) + mismatch * diffs;
   }
 
-  static score_t
-  count_insertions(const std::string &cigar) {
-    score_t ans = 0;
-    const auto lim = std::end(cigar);
-    for (auto it(begin(cigar)); it !=  lim; ++it) {
-      ans += (extract_op_count(it, lim)) * (*it == 'I');
-    }
-    return ans;
-  }
-
-  inline score_t
-  mismatch_score(const uint8_t q_base, const uint8_t t_base) {
+  inline score_t mismatch_score(const uint8_t q_base, const uint8_t t_base) {
     return score_lookup[(q_base & t_base) == 0];
   }
 
   // edit distance as a function of aln_score and len
   inline score_t edit_distance(const score_t scr, const uint32_t len,
-                               const std::string &cigar) {
+                               const bam_cigar_t &cigar) {
     if (scr == 0) return len;
     const score_t ins = count_insertions(cigar);
     const score_t del = count_deletions(cigar);
@@ -80,36 +85,36 @@ namespace simple_aln {
     // A = S - (indel_pen) = match*M + mismatch*m
     // B = len - ins = M + m
     // m = (match*(len - ins) - A)/(match - mismatch)
-    const score_t A = scr - indel*(ins + del);
-    const score_t mism = (match*(len - ins) - A)/(match - mismatch);
+    const score_t A = scr - indel * (ins + del);
+    const score_t mism = (match * (len - ins) - A) / (match - mismatch);
 
     return mism + ins + del;
   }
 
-  inline score_t
-  best_single_score(const uint32_t readlen) {
-    return match*readlen;
+  inline score_t best_single_score(const uint32_t readlen) {
+    return match * readlen;
   }
 
-  inline score_t
-  best_pair_score(const uint32_t readlen1, const uint32_t readlen2) {
+  inline score_t best_pair_score(const uint32_t readlen1,
+                                 const uint32_t readlen2) {
     return best_single_score(readlen1) + best_single_score(readlen2);
   }
-};
+};  // namespace simple_aln
 
-
-template <score_t (*scr_fun)(const uint8_t, const uint8_t),
-          score_t indel_pen = -1>
+template<score_t (*scr_fun)(const uint8_t, const uint8_t),
+         score_t indel_pen = -1>
 struct AbismalAlign {
-
-  AbismalAlign(const genome_iterator &target_start);
+  AbismalAlign(const genome_iterator &target_start)
+    : target(target_start), bw(2 * max_off_diag + 1) {}
 
   template<const bool do_traceback>
   score_t align(const score_t diffs, const score_t max_diffs,
-      const std::vector<uint8_t> &query,
-      const uint32_t t_pos);
+                const std::vector<uint8_t> &query, const uint32_t t_pos);
+
   void build_cigar_len_and_pos(const score_t diffs, const score_t max_diffs,
-      std::string &cigar, uint32_t &len, uint32_t &t_pos);
+                               bam_cigar_t &cigar, uint32_t &len,
+                               uint32_t &t_pos);
+
   void reset(const uint32_t max_read_length);
 
   std::vector<score_t> table;
@@ -126,25 +131,20 @@ struct AbismalAlign {
   static const size_t max_off_diag = 30;
 };
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t),
-          score_t indel_pen>
-AbismalAlign<scr_fun, indel_pen>::AbismalAlign(
-    const genome_iterator &target_start) : target(target_start),
-    bw(2*max_off_diag + 1) {}
-
-template <score_t (*scr_fun)(const uint8_t, const uint8_t),
-          score_t indel_pen> void
-AbismalAlign<scr_fun, indel_pen>::reset(const uint32_t max_read_length) {
+template<score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
+void
+AbismalAlign<scr_fun, indel_pen>::reset(
+  const uint32_t max_read_length) {  // uses cigar
   q_sz_max = max_read_length;
 
   // size of alignment matrix and traceback matrix is maximum query
   // length times the width of the band around the diagonal
-  const size_t n_cells = (q_sz_max + bw)*bw;
+  const size_t n_cells = (q_sz_max + bw) * bw;
   table.resize(n_cells);
   traceback.resize(n_cells, ' ');
 
   // the largest cigar is 1I1D for each qseq_op
-  cigar_scratch.resize(4*q_sz_max);
+  cigar_scratch.resize(4 * q_sz_max);
 }
 
 // for making the CIGAR string
@@ -155,69 +155,60 @@ static const uint8_t soft_clip_symbol = 'S';
 
 static inline bool
 is_deletion(const uint8_t c) {
-  return c == above_symbol; // consumes reference
+  return c == above_symbol;  // consumes reference
 }
+
 static inline bool
 is_insertion(const uint8_t c) {
-  return c == left_symbol; // does not consume reference
+  return c == left_symbol;  // does not consume reference
 }
 
 static inline void
-get_traceback(const size_t n_col,
-              const std::vector<score_t> &table,
+get_traceback(const size_t n_col, const std::vector<score_t> &table,
               const std::vector<uint8_t> &traceback,
-              size_t &the_row, size_t &the_col) {
-  score_t score = table[the_row*n_col + the_col];
-  while (score != 0) {
-    const uint8_t the_arrow = traceback[the_row*n_col + the_col];
-    const bool is_del = is_deletion(the_arrow);
-    const bool is_ins = is_insertion(the_arrow);
+              std::vector<uint32_t> &cigar, size_t &the_row, size_t &the_col) {
+  uint8_t prev_arrow = traceback[the_row * n_col + the_col];
+  const bool is_del = is_deletion(prev_arrow);
+  const bool is_ins = is_insertion(prev_arrow);
+  the_row -= !is_ins;
+  the_col -= is_ins;
+  the_col += is_del;  // ADS: straight up IS diagonal!
+  uint32_t n = 1;
+  while (table[the_row * n_col + the_col] > 0) {
+    const uint8_t arrow = traceback[the_row * n_col + the_col];
+    const bool is_del = is_deletion(arrow);
+    const bool is_ins = is_insertion(arrow);
     the_row -= !is_ins;
     the_col -= is_ins;
     the_col += is_del;
-    score = table[the_row*n_col + the_col];
+    if (arrow != prev_arrow) {
+      cigar.emplace_back(bam_cigar_gen(n, bam_cigar_table[prev_arrow]));
+      n = 0;
+    }
+    ++n;
+    prev_arrow = arrow;
   }
+  cigar.emplace_back(bam_cigar_gen(n, bam_cigar_table[prev_arrow]));
 }
 
-static inline void
-get_traceback(const size_t n_col,
-              const std::vector<score_t> &table,
-              const std::vector<uint8_t> &traceback,
-              std::vector<uint8_t>::iterator &c_itr,
-              size_t &the_row, size_t &the_col) {
-  score_t score = table[the_row*n_col + the_col];
-  while (score != 0) {
-    const uint8_t the_arrow = traceback[the_row*n_col + the_col];
-    const bool is_del = is_deletion(the_arrow);
-    const bool is_ins = is_insertion(the_arrow);
-    the_row -= !is_ins;
-    the_col -= is_ins;
-    the_col += is_del;
-    *c_itr = the_arrow;
-    ++c_itr;
-    score = table[the_row*n_col + the_col];
-  }
-}
-
-template <class T> inline void
+template<class T> inline void
 max16(T &a, const T b) {
-  a = ((a>b) ? a : b);
+  a = ((a > b) ? a : b);
 }
 
-template <class T> inline T
+template<class T> inline T
 min16(const T a, const T b) {
-  return  ((a<b) ? a : b);
+  return ((a < b) ? a : b);
 }
 
 static score_t
-get_best_score(const std::vector<score_t> &table,
-               const size_t n_cells,
-               const size_t n_col,
-               const size_t t_shift,
-               size_t &best_i, size_t &best_j) {
-  auto best_cell_itr = std::max_element(std::begin(table), std::begin(table) + n_cells);
+get_best_score(const std::vector<score_t> &table, const size_t n_cells,
+               const size_t n_col, const size_t t_shift, size_t &best_i,
+               size_t &best_j) {
+  auto best_cell_itr =
+    std::max_element(std::begin(table), std::begin(table) + n_cells);
   const size_t best_cell = std::distance(std::begin(table), best_cell_itr);
-  best_i = best_cell/n_col;
+  best_i = best_cell / n_col;
   best_j = best_cell % n_col;
   return *best_cell_itr;
 }
@@ -228,19 +219,18 @@ get_best_score(const std::vector<score_t> &table,
 // here helps, and below we restore it to the `-O3` default.
 #pragma GCC optimize("vect-cost-model=very-cheap")
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t),
-          class T, class QueryConstItr>
+template<score_t (*scr_fun)(const uint8_t, const uint8_t), class T,
+         class QueryConstItr>
 void
-from_diag(T next_row, const T next_row_end, T cur_row,
-          QueryConstItr query_seq, uint8_t ref_base) {
+from_diag(T next_row, const T next_row_end, T cur_row, QueryConstItr query_seq,
+          uint8_t ref_base) {
   while (next_row != next_row_end) {
     const score_t score = scr_fun(*query_seq++, ref_base) + *cur_row++;
     max16(*next_row++, score);
   }
 }
 
-template <score_t indel_pen, class T>
-void
+template<score_t indel_pen, class T> void
 from_above(T above_itr, const T above_end, T target) {
   while (above_itr != above_end) {
     const score_t score = *above_itr++ + indel_pen;
@@ -250,8 +240,7 @@ from_above(T above_itr, const T above_end, T target) {
 
 // ADS: from_left is the same function as from_above, but uses
 // different order on arguments, so rewritten to be more intuitive.
-template <score_t indel_pen, class T>
-void
+template<score_t indel_pen, class T> void
 from_left(T left_itr, T target, const T target_end) {
   while (target != target_end) {
     const score_t score = *left_itr++ + indel_pen;
@@ -259,75 +248,81 @@ from_left(T left_itr, T target, const T target_end) {
   }
 }
 
-
 /********* SAME FUNCTIONS AS ABOVE BUT WITH TRACEBACK ********/
-template <score_t (*scr_fun)(const uint8_t, const uint8_t),
-          class T, class QueryConstItr, class U>
+template<score_t (*scr_fun)(const uint8_t, const uint8_t), class T,
+         class QueryConstItr, class U>
 void
-from_diag(T next_row, const T next_row_end, T cur_row,
-          QueryConstItr query_seq, uint8_t ref_base, U traceback) {
+from_diag(T next_row, const T next_row_end, T cur_row, QueryConstItr query_seq,
+          uint8_t ref_base, U traceback) {
   while (next_row != next_row_end) {
     const score_t score = scr_fun(*query_seq, ref_base) + *cur_row;
     max16(*next_row, score);
     *traceback = (*next_row == score) ? (diag_symbol) : (*traceback);
-    ++traceback; ++next_row; ++query_seq; ++cur_row;
+    ++traceback;
+    ++next_row;
+    ++query_seq;
+    ++cur_row;
   }
 }
 
-template <score_t indel_pen,
-         class T, class U>
-void
+template<score_t indel_pen, class T, class U> void
 from_above(T above_itr, const T above_end, T target, U traceback) {
   while (above_itr != above_end) {
     const score_t score = *above_itr + indel_pen;
     max16(*target, score);
     *traceback = (*target == score) ? (above_symbol) : (*traceback);
-    ++traceback; ++above_itr; ++target;
+    ++traceback;
+    ++above_itr;
+    ++target;
   }
 }
 
-template <score_t indel_pen, class T, class U>
-void
+template<score_t indel_pen, class T, class U> void
 from_left(T left_itr, T target, const T target_end, U traceback) {
   while (target != target_end) {
     const score_t score = *left_itr + indel_pen;
     max16(*target, score);
     *traceback = (*target == score) ? (left_symbol) : (*traceback);
-    ++traceback; ++left_itr; ++target;
+    ++traceback;
+    ++left_itr;
+    ++target;
   }
 }
-#pragma GCC optimize("vect-cost-model=dynamic")
 
+#pragma GCC optimize("vect-cost-model=dynamic")
 
 inline void
 make_default_cigar(const uint32_t len, std::string &cigar) {
   cigar = std::to_string(len) + 'M';
 }
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
-template <const bool do_traceback>
-score_t
-AbismalAlign<scr_fun, indel_pen>::align(
-    const score_t diffs,
-    const score_t max_diffs,
-    const std::vector<uint8_t> &qseq,
-    const uint32_t t_pos) {
+inline void
+make_default_cigar(const uint32_t len, bam_cigar_t &cigar) {
+  cigar = {bam_cigar_gen(len, 0)};
+}
+
+template<score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
+template<const bool do_traceback> score_t
+AbismalAlign<scr_fun, indel_pen>::align(const score_t diffs,
+                                        const score_t max_diffs,
+                                        const std::vector<uint8_t> &qseq,
+                                        const uint32_t t_pos) {
   q_sz = qseq.size();
   // edge case: diffs = 0 so alignment is "trivial"
-  if (diffs == 0)
-    return simple_aln::best_single_score(q_sz);
+  if (diffs == 0) return simple_aln::best_single_score(q_sz);
 
   // if diffs is small bw can be reduced
   const size_t bandwidth =
-    min16(bw, static_cast<size_t>(2*min16(diffs, max_diffs) + 1));
-  const size_t n_cells = (q_sz + bandwidth)*bandwidth;
+    min16(bw, static_cast<size_t>(2 * min16(diffs, max_diffs) + 1));
+  const size_t n_cells = (q_sz + bandwidth) * bandwidth;
 
   std::fill(std::begin(table), std::begin(table) + n_cells, 0);
-  std::fill(std::begin(traceback), std::begin(traceback) + n_cells, ' ');
+  if (do_traceback)
+    std::fill(std::begin(traceback), std::begin(traceback) + n_cells, ' ');
 
   // GS: non-negative because of padding. The mapper
   // must ensure t_pos is large enough when calling the function
-  const size_t t_beg = t_pos - ((bandwidth - 1)/2);
+  const size_t t_beg = t_pos - ((bandwidth - 1) / 2);
   const size_t t_shift = q_sz + bandwidth;
 
   // points to relevant reference sequence positions
@@ -343,13 +338,16 @@ AbismalAlign<scr_fun, indel_pen>::align(
     const size_t left = (i < bandwidth ? bandwidth - i : 0);
     const size_t right = min16(bandwidth, t_shift - i);
 
-    cur += bandwidth; // next row in aln matrix
+    cur += bandwidth;  // next row in aln matrix
     if (do_traceback) {
-      tb_cur += bandwidth; // next row in traceback
+      tb_cur += bandwidth;  // next row in traceback
       from_diag<scr_fun>(cur + left, cur + right, prev + left,
-                         q_itr + (i > bandwidth ? i - bandwidth : 0), *t_itr, tb_cur + left);
-      from_above<indel_pen>(prev + left + 1, prev + right, cur + left, tb_cur + left);
-      from_left<indel_pen>(cur + left, cur + left + 1, cur + right, tb_cur + left + 1);
+                         q_itr + (i > bandwidth ? i - bandwidth : 0), *t_itr,
+                         tb_cur + left);
+      from_above<indel_pen>(prev + left + 1, prev + right, cur + left,
+                            tb_cur + left);
+      from_left<indel_pen>(cur + left, cur + left + 1, cur + right,
+                           tb_cur + left + 1);
     }
     else {
       from_diag<scr_fun>(cur + left, cur + right, prev + left,
@@ -358,62 +356,60 @@ AbismalAlign<scr_fun, indel_pen>::align(
       from_left<indel_pen>(cur + left, cur + left + 1, cur + right);
     }
     ++t_itr;
-    prev += bandwidth; // update previous row
+    prev += bandwidth;  // update previous row
   }
 
   // locate the end of the alignment as max score
   size_t the_row = 0, the_col = 0;
-  return get_best_score(table, n_cells, bandwidth, q_sz + bandwidth, the_row, the_col);
+  return get_best_score(table, n_cells, bandwidth, q_sz + bandwidth, the_row,
+                        the_col);
 }
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
+template<score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
 void
-AbismalAlign<scr_fun, indel_pen>::build_cigar_len_and_pos(
-    const score_t diffs, const score_t max_diffs,
-    std::string &cigar, uint32_t &len,
-    uint32_t &t_pos) {
+AbismalAlign<scr_fun, indel_pen>::build_cigar_len_and_pos(  // uses cigar
+  const score_t diffs, const score_t max_diffs, bam_cigar_t &cigar,
+  uint32_t &len, uint32_t &t_pos) {
   // locate the end of the alignment as max score
-  const size_t bandwidth = min16(bw, static_cast<size_t>(2*min16(diffs, max_diffs) + 1));
-  const size_t n_cells = (q_sz + bandwidth)*bandwidth;
+  const size_t bandwidth =
+    min16(bw, static_cast<size_t>(2 * min16(diffs, max_diffs) + 1));
+  const size_t n_cells = (q_sz + bandwidth) * bandwidth;
   size_t the_row = 0, the_col = 0;
-  const score_t r = get_best_score(table, n_cells, bandwidth, q_sz + bandwidth, the_row, the_col);
+  const score_t r = get_best_score(table, n_cells, bandwidth, q_sz + bandwidth,
+                                   the_row, the_col);
 
   // GS: unlikely, but possible, case where the score = 0, which
   // degenerates CIGAR string below
   if (r == 0 || diffs == 0) {
-    cigar = std::to_string(q_sz) + "M";
+    make_default_cigar(q_sz, cigar);
     len = q_sz;
     // t_pos does not change in this case
     return;
   }
 
-  auto c_itr(std::begin(cigar_scratch));
-
   // soft clip "S" at the start of the (reverse) uncompressed cigar
-  const size_t soft_clip_bottom = (q_sz + (bandwidth - 1)) - (the_row + the_col);
-  std::fill_n(c_itr, soft_clip_bottom, soft_clip_symbol);
-  c_itr += soft_clip_bottom;
+  const size_t soft_clip_bottom =
+    (q_sz + (bandwidth - 1)) - (the_row + the_col);
 
   // run traceback, the_row and the_col now point to start of tb
-  get_traceback(bandwidth, table, traceback, c_itr, the_row, the_col);
+  cigar.clear();
+  get_traceback(bandwidth, table, traceback, cigar, the_row, the_col);
 
   // soft clip "S" at the end of the (reverse) uncompressed cigar
   const size_t soft_clip_top = (the_row + the_col) - (bandwidth - 1);
-  std::fill_n(c_itr, soft_clip_top, soft_clip_symbol);
-  c_itr += soft_clip_top;
 
-  // put the uncompressed cigar back in the forward orientation
-  std::reverse(std::begin(cigar_scratch), c_itr);
+  if (soft_clip_top > 0)
+    cigar.emplace_back(bam_cigar_gen(soft_clip_top, BAM_CSOFT_CLIP));
 
-  cigar.resize(4*q_sz);
-  compress_cigar(begin(cigar_scratch), c_itr, cigar);
+  std::reverse(std::begin(cigar), std::end(cigar));
+
+  if (soft_clip_bottom > 0)
+    cigar.emplace_back(bam_cigar_gen(soft_clip_bottom, BAM_CSOFT_CLIP));
 
   len = q_sz - soft_clip_bottom - soft_clip_top;
 
-  const size_t t_beg = t_pos - ((bandwidth - 1)/2);
+  const size_t t_beg = t_pos - ((bandwidth - 1) / 2);
   t_pos = t_beg + the_row;
 }
-
-
 
 #endif

--- a/src/AbismalAlign.hpp
+++ b/src/AbismalAlign.hpp
@@ -1,6 +1,6 @@
-/* Copyright (C) 2019-2023 Andrew D. Smith
+/* Copyright (C) 2019-2023 Andrew D. Smith and Guil Sena
  *
- * Authors: Andrew D. Smith
+ * Authors: Andrew D. Smith and Guil Sena
  *
  * This file is part of ABISMAL.
  *

--- a/src/abismal.cpp
+++ b/src/abismal.cpp
@@ -364,16 +364,17 @@ struct se_candidates {
 
 const uint32_t se_candidates::max_size = 50u;
 
-inline bool
+static inline bool
 cigar_eats_ref(const uint32_t c) {
   return bam_cigar_type(bam_cigar_op(c)) & 2;
 }
-inline bool
+
+static inline bool
 cigar_eats_query(const uint32_t c) {
   return bam_cigar_type(bam_cigar_op(c)) & 1;
 }
 
-inline uint32_t
+static inline uint32_t
 cigar_rseq_ops(const bam_cigar_t &cig) {
   return accumulate(begin(cig), end(cig), 0u,
                     [](const uint32_t total, const uint32_t x)
@@ -381,7 +382,7 @@ cigar_rseq_ops(const bam_cigar_t &cig) {
                     );
 }
 
-inline uint32_t
+static inline uint32_t
 cigar_qseq_ops(const bam_cigar_t &cig) {
   return accumulate(begin(cig), end(cig), 0u,
                     [](const uint32_t total, const uint32_t x)
@@ -699,7 +700,7 @@ struct pe_candidates {
   static const uint32_t max_size_large = (max_size_small) << 10u;
 };
 
-inline double
+static inline double
 pct(const double a, const double b) {
   return ((b == 0) ? 0.0 : 100.0 * a / b);
 }

--- a/src/abismal_cigar_utils.hpp
+++ b/src/abismal_cigar_utils.hpp
@@ -1,0 +1,53 @@
+/* Copyright (C) 2023 Andrew D. Smith and Guil Sena
+ *
+ * Authors: Andrew D. Smith and Guil Sena
+ *
+ * This file is part of ABISMAL.
+ *
+ * ABISMAL is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ABISMAL is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ */
+
+#ifndef ABISMAL_CIGAR_UTILS_HPP
+#define ABISMAL_CIGAR_UTILS_HPP
+
+// This file has equivalent functions and definitions as in HTSlib but
+// just what's needed so HTSlib shouldn't be needed for AbismalAlign
+// compile
+
+static const int8_t ABISMAL_BAM_CMATCH = 0;
+static const int8_t ABISMAL_BAM_CINS = 1;
+static const int8_t ABISMAL_BAM_CDEL = 2;
+static const int8_t ABISMAL_BAM_CREF_SKIP = 3;
+static const int8_t ABISMAL_BAM_CSOFT_CLIP = 4;
+static const int8_t ABISMAL_BAM_CHARD_CLIP = 5;
+static const int8_t ABISMAL_BAM_CPAD = 6;
+static const int8_t ABISMAL_BAM_CEQUAL = 7;
+static const int8_t ABISMAL_BAM_CDIFF = 8;
+static const int8_t ABISMAL_BAM_CBACK = 9;
+static const uint32_t ABISMAL_BAM_CIGAR_SHIFT = 4;
+
+inline uint32_t
+abismal_bam_cigar_gen(const uint32_t l, const int8_t o) {
+  // ADS: "o" can have -1 for invalid cigar ops
+  return (l << ABISMAL_BAM_CIGAR_SHIFT| static_cast<uint32_t>(o));
+}
+
+static const uint8_t ABISMAL_BAM_CIGAR_MASK = 0xf;
+
+inline uint8_t
+abismal_bam_cigar_op(const uint32_t c) { return c & ABISMAL_BAM_CIGAR_MASK; }
+
+inline uint8_t
+abismal_bam_cigar_oplen(const uint32_t c) {
+  return c >> ABISMAL_BAM_CIGAR_SHIFT;
+}
+
+#endif


### PR DESCRIPTION
Slight change to functionality: abismal can now output BAM format directly, without a pipe through samtools view. This introduces a dependence on HTSlib, but has other advantages. The FASTQ input files will be able to be decompressed using threads if needed, and cigar are now built directly without first creating intermediate "expanded" cigar strings.