### PR TITLE
macOS build worflow

### DIFF
--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -2,6 +2,10 @@ name: Abismal builds on macOS
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install autotools
       run: brew install autoconf automake libtool
     - name: Install dependencies
-      run: brew install htslib gsl samtools
+      run: brew install htslib gsl
     - name: Generate configure script
       run: ./autogen.sh
     - name: configure with g++-12

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -17,6 +17,6 @@ jobs:
     - name: Generate configure script
       run: ./autogen.sh
     - name: configure with g++-12
-      run: ./configure CXX="g++-12"
+      run: ./configure CXX="g++-12" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
       run: make


### PR DESCRIPTION
Tests build on macOS 13 using gcc-12 (pre-installed) and brew to get HTSlib.