### PR TITLE
Option for better mapping of very short reads

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,10 @@ install installdirs: SUBDIRS := $(filter-out src/smithlab_cpp, $(SUBDIRS))
 AM_CPPFLAGS = -I $(top_srcdir)/src/smithlab_cpp -I $(top_srcdir)/src/bamxx
 
 AM_CXXFLAGS = $(OPENMP_CXXFLAGS)
+if ENABLE_VERY_SHORT
+AM_CXXFLAGS += -DENABLE_VERY_SHORT
+endif
+
 CXXFLAGS = -O3 # default has optimization on
 
 noinst_LIBRARIES = libabismal.a

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,18 @@ dnl now we get setup for the right OpenMP flags
 ADS_OPENMP([], [AC_MSG_FAILURE([OpenMP must be installed to build abismal])])
 ])dnl end of OpenMP stuff
 
+
+dnl Optimize for shorter reads by compiling with a smaller window when
+dnl making the index. When abismal loads the index, it compares the
+dnl value with a constant so abismalidx and abismal must both be
+dnl compiled this way to work together.
+AC_ARG_ENABLE([short],
+  [AS_HELP_STRING([--enable-very-short],
+                  [optimize for very short reads @<:@no@:>@])],
+  [enable_very_short=yes], [enable_very_short=no])
+AM_CONDITIONAL([ENABLE_VERY_SHORT], [test "x$enable_very_short" = "xyes"])
+
+
 AC_CONFIG_FILES([
 Makefile
 ])

--- a/src/AbismalIndex.cpp
+++ b/src/AbismalIndex.cpp
@@ -851,39 +851,39 @@ write_internal_identifier(FILE *out) {
 
 void
 seed::read(FILE *in) {
-  static const std::string error_msg("failed to read seed data");
-  uint32_t _key_weight = 0;
-  uint32_t _window_size = 0;
-  uint32_t _n_sorting_positions = 0;
+  static constexpr auto error_msg{"failed to read seed data"};
 
   // key_weight
-  if (fread((char *)&_key_weight, sizeof(uint32_t), 1, in) != 1)
+  uint32_t key_weight_from_file = 0;
+  if (fread((char *)&key_weight_from_file, sizeof(uint32_t), 1, in) != 1)
     throw runtime_error(error_msg);
 
-  if (_key_weight != key_weight) {
+  if (key_weight_from_file != key_weight) {
     throw runtime_error(
       "inconsistent k-mer size. Expected: " + to_string(key_weight) +
-      ", got: " + to_string(_key_weight));
+      ", got: " + to_string(key_weight_from_file));
   }
 
   // window_size
-  if (fread((char *)&_window_size, sizeof(uint32_t), 1, in) != 1)
+  uint32_t window_size_from_file = 0;
+  if (fread((char *)&window_size_from_file, sizeof(uint32_t), 1, in) != 1)
     throw runtime_error(error_msg);
 
-  if (_window_size != window_size) {
+  if (window_size_from_file != window_size) {
     throw runtime_error(
       "inconsistent window size size. Expected: " + to_string(window_size) +
-      ", got: " + to_string(_window_size));
+      ", got: " + to_string(window_size_from_file));
   }
 
   // n_sorting_positions
-  if (fread((char *)&_n_sorting_positions, sizeof(uint32_t), 1, in) != 1)
+  uint32_t n_sorting_positions_from_file = 0;
+  if (fread((char *)&n_sorting_positions_from_file, sizeof(uint32_t), 1, in) != 1)
     throw runtime_error(error_msg);
 
-  if (_n_sorting_positions != n_sorting_positions) {
+  if (n_sorting_positions_from_file != n_sorting_positions) {
     throw runtime_error("inconsistent sorting size size. Expected: " +
                         to_string(n_sorting_positions) +
-                        ", got: " + to_string(_n_sorting_positions));
+                        ", got: " + to_string(n_sorting_positions_from_file));
   }
 }
 

--- a/src/AbismalIndex.hpp
+++ b/src/AbismalIndex.hpp
@@ -70,7 +70,11 @@ namespace seed {
   // window in which we select the best k-mer. The longer it is,
   // the longer the minimum read length that guarantees an exact
   // match will be mapped
+#ifdef ENABLE_VERY_SHORT
+  static const uint32_t window_size = 12u;
+#else
   static const uint32_t window_size = 20u;
+#endif
 
   // number of positions to sort within buckets
   static const uint32_t n_sorting_positions = 256u;


### PR DESCRIPTION
- Moving declaration of variables closer to their use and renaming to avoid leading underscore
- Makefile.am: adding a condition to check if the user wants the enable very short option
- configure.ac: adding the logic for the user option to enable optimizations for very short reads
- AbismalIndex.hpp: if the user asks for optimizations for very short reads then a compile variable is used to set the window_size to 12 instead of 20. This will be slower for long reads, but much more accurate for reads under 46 bases
