### PR TITLE
Fixing macos build script

### DIFF
--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
       with:
         submodules: recursive
     - name: Update Homebrew

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -10,10 +10,10 @@ on:
 jobs:
   build:
 
-    runs-on: macos-13
+    runs-on: macos-14
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Update Homebrew

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -1,4 +1,4 @@
-name: Abismal builds on macOS
+name: Abismal builds on macOS (x86)
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
       with:

--- a/src/abismal.cpp
+++ b/src/abismal.cpp
@@ -1002,7 +1002,7 @@ check_hits(const uint32_t offset, const PackedRead::const_iterator read_st,
            vector<uint32_t>::const_iterator start_idx, result_type &res) {
   for (; start_idx != end_idx && !res.sure_ambig; ++start_idx) {
     // GS: adds the next candidate to L1d cache while current is compared
-#ifndef __arm__
+#ifndef __arm64__
     _mm_prefetch(&(*(genome_st + ((*(start_idx + 10) - offset) >> 4))),
                  _MM_HINT_T0);
 #endif

--- a/src/abismal.cpp
+++ b/src/abismal.cpp
@@ -1002,8 +1002,10 @@ check_hits(const uint32_t offset, const PackedRead::const_iterator read_st,
            vector<uint32_t>::const_iterator start_idx, result_type &res) {
   for (; start_idx != end_idx && !res.sure_ambig; ++start_idx) {
     // GS: adds the next candidate to L1d cache while current is compared
+#ifndef __arm__
     _mm_prefetch(&(*(genome_st + ((*(start_idx + 10) - offset) >> 4))),
                  _MM_HINT_T0);
+#endif
     const uint32_t the_pos = *start_idx - offset;
     /* GS: the_pos & 15u tells if the position is a multiple of 16, in
      * which case it is aligned with the genome. Otherwise we need to

--- a/src/abismal.cpp
+++ b/src/abismal.cpp
@@ -1002,10 +1002,8 @@ check_hits(const uint32_t offset, const PackedRead::const_iterator read_st,
            vector<uint32_t>::const_iterator start_idx, result_type &res) {
   for (; start_idx != end_idx && !res.sure_ambig; ++start_idx) {
     // GS: adds the next candidate to L1d cache while current is compared
-#ifndef __arm64__
     _mm_prefetch(&(*(genome_st + ((*(start_idx + 10) - offset) >> 4))),
                  _MM_HINT_T0);
-#endif
     const uint32_t the_pos = *start_idx - offset;
     /* GS: the_pos & 15u tells if the position is a multiple of 16, in
      * which case it is aligned with the genome. Otherwise we need to


### PR DESCRIPTION
- Update macos-builds.yml
- Update to g++-13
- Adding directives to check for ARM for Apple M1 and remove the prefetch intrinsic
- Another attempt at adding directives to check for ARM for Apple M1 and remove the prefetch intrinsic
- Reverting the macos runner back to macos-13 so it will be x86; need to figure out how to handle the M1
- Removing the check for macos
- Trying to find a macos config that works without using apple linker
