### PR TITLE
update alignment optimizations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,7 @@ if ENABLE_SHORT
 AM_CXXFLAGS += -DENABLE_SHORT
 endif
 
-CXXFLAGS = -O3 # default has optimization on
+CXXFLAGS = -O3 -DNDEBUG # default has optimization on
 
 noinst_LIBRARIES = libabismal.a
 


### PR DESCRIPTION
- Adding NDEBUG to default optimizations in Makefile.am
- Updating the pragma guard for optimizations in the alignment code that will hopefully prevent the problems seen on macs but work on more compilers. Not an ideal fix.
