### PR TITLE
further optimization fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,6 +38,7 @@ install installdirs: SUBDIRS := $(filter-out src/smithlab_cpp, $(SUBDIRS))
 AM_CPPFLAGS = -I $(top_srcdir)/src/smithlab_cpp -I $(top_srcdir)/src/bamxx
 
 AM_CXXFLAGS = $(OPENMP_CXXFLAGS)
+AM_CXXFLAGS += -Wall -Wextra -Wpedantic -Wno-unknown-attributes
 if ENABLE_SHORT
 AM_CXXFLAGS += -DENABLE_SHORT
 endif


### PR DESCRIPTION
- Makefile.am: adding warnings and ignoring unknown attributes for the optimization __attribute__ in AbismalAlign.hpp
- AbismalAlign.hpp: Changing the way loop vectorization is turned off for the from_diag functions to now use __attribute__ instead of pragmas and hopefully fewer compilers will have a problem with this
