### PR TITLE
Preventing attempts to use SSE instruction when not supported

### DIFF
--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Update Homebrew
       run: brew update
     - name: Install autotools
-      run: brew install automake
+      run: brew install autoconf automake libtool
     - name: Install dependencies
       run: brew install htslib gsl
     - name: Generate configure script

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -9,15 +9,15 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Update Homebrew
       run: brew update
-    - name: Install autotools
-      run: brew install autoconf automake libtool
+    - name: Install automake (autoconf and libtool assumed present)
+      run: brew install automake
     - name: Install dependencies
       run: brew install htslib gsl
     - name: Generate configure script

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -25,4 +25,4 @@ jobs:
     - name: configure with g++-13
       run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
-      run: make CXXFLAGS="-Wl,-ld_classic"
+      run: make

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v4
       with:
@@ -19,13 +19,13 @@ jobs:
     - name: Install automake (autoconf and libtool assumed present)
       run: brew install automake
     - name: Install dependencies
-      run: brew install htslib gsl
+      run: brew install htslib
     - name: Generate configure script
       run: ./autogen.sh
-    - name: configure with g++-13
-      run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
+    - name: configure with g++-12
+      run: ./configure CXX="g++-12" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
-      run: make CXXFLAGS="-O2 -DNDEBUG -Wl,-ld_classic"
+      run: make CXXFLAGS="-O2 -DNDEBUG"
     - name: Run tests
       run: make check
     - name: Cleanup after build and test

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -25,7 +25,7 @@ jobs:
     - name: configure with g++-13
       run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
-      run: make CXXFLAGS="-O3 -DNDEBUG -Wl,-ld_classic"
+      run: make CXXFLAGS="-O2 -DNDEBUG -Wl,-ld_classic"
     - name: Run tests
       run: make check
     - name: Cleanup after build and test

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -11,13 +11,13 @@ jobs:
   build:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Update Homebrew
       run: brew update
     - name: Install autotools
-      run: brew install autoconf automake libtool
+      run: brew install automake
     - name: Install dependencies
       run: brew install htslib gsl
     - name: Generate configure script
@@ -25,4 +25,4 @@ jobs:
     - name: configure with g++-13
       run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
-      run: make
+      run: make CXXFLAGS="-Wl,-ld_classic"

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -25,4 +25,4 @@ jobs:
     - name: configure with g++-13
       run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
-      run: make
+      run: make CXXFLAGS="-O3 -DNDEBUG -Wl,-ld_classic"

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -26,3 +26,7 @@ jobs:
       run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
     - name: make
       run: make CXXFLAGS="-O3 -DNDEBUG -Wl,-ld_classic"
+    - name: Run tests
+      run: make check
+    - name: Cleanup after build and test
+      run: make distclean

--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -9,24 +9,20 @@ on:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Update Homebrew
       run: brew update
-    - name: Install automake (autoconf and libtool assumed present)
+    - name: Install automake
       run: brew install automake
     - name: Install dependencies
       run: brew install htslib
     - name: Generate configure script
       run: ./autogen.sh
-    - name: configure with g++-12
-      run: ./configure CXX="g++-12" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
-    - name: make
-      run: make CXXFLAGS="-O2 -DNDEBUG"
-    - name: Run tests
-      run: make check
-    - name: Cleanup after build and test
-      run: make distclean
+    - name: configure with g++-13
+      run: ./configure CXX="g++-13" CPPFLAGS="-I$(brew --prefix)/include" LDFLAGS="-L$(brew --prefix)/lib"
+    - name: Build with g++
+      run: make CXXFLAGS="-O3 -DNDEBUG -Wl,-ld_classic"

--- a/.github/workflows/ubuntu-builds.yml
+++ b/.github/workflows/ubuntu-builds.yml
@@ -26,8 +26,6 @@ jobs:
       run: ./configure CXX="g++"
     - name: make with g++
       run: make
-    - name: test
-      run: make check
     - name: cleanup after GCC
       run: make distclean
     - name: install Clang dependencies

--- a/.github/workflows/ubuntu-builds.yml
+++ b/.github/workflows/ubuntu-builds.yml
@@ -26,6 +26,8 @@ jobs:
       run: ./configure CXX="g++"
     - name: make with g++
       run: make
+    - name: test
+      run: make check
     - name: cleanup after GCC
       run: make distclean
     - name: install Clang dependencies

--- a/src/abismal.cpp
+++ b/src/abismal.cpp
@@ -1002,8 +1002,10 @@ check_hits(const uint32_t offset, const PackedRead::const_iterator read_st,
            vector<uint32_t>::const_iterator start_idx, result_type &res) {
   for (; start_idx != end_idx && !res.sure_ambig; ++start_idx) {
     // GS: adds the next candidate to L1d cache while current is compared
+#ifdef __SSE__
     _mm_prefetch(&(*(genome_st + ((*(start_idx + 10) - offset) >> 4))),
                  _MM_HINT_T0);
+#endif
     const uint32_t the_pos = *start_idx - offset;
     /* GS: the_pos & 15u tells if the position is a multiple of 16, in
      * which case it is aligned with the genome. Otherwise we need to


### PR DESCRIPTION
This should help the code to build on a broader set of macOS versions. It requires a preprocessor guard around the `_mm_prefetch` instruction and in the GitHub workflow to test builds on macOS, if `macos-14` is used, then the linker options need to include `-ld_classic`.