### PR TITLE
Replacing OpenMP with std::thread

### DIFF
--- a/src/AbismalIndex.hpp
+++ b/src/AbismalIndex.hpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
@@ -150,6 +151,7 @@ struct AbismalIndex {
   static bool VERBOSE;
 
   static const uint32_t max_n_count = 256ul;
+  static std::size_t n_threads_global;
 
   uint32_t max_candidates{100u};
 
@@ -177,6 +179,12 @@ struct AbismalIndex {
 
   Genome genome;   // the genome
   ChromLookup cl;  // the starting position of each chromosome
+
+  static void
+  set_n_threads(const std::uint32_t &n_threads_arg) {
+    n_threads_global =
+      std::min(std::thread::hardware_concurrency(), n_threads_arg);
+  }
 
   void
   create_index(const std::string &genome_file);

--- a/src/abismalidx.cpp
+++ b/src/abismalidx.cpp
@@ -1,4 +1,4 @@
-/* Copyright (C) 2018 Andrew D. Smith and Meng Zhou
+/* Copyright (C) 2018-2025 Andrew D. Smith and Guilherme de Sena Brandine
  *
  * Authors: Andrew D. Smith and Guilherme de Sena Brandine
  *
@@ -16,17 +16,17 @@
  */
 
 #include "abismalidx.hpp"
-#include "AbismalIndex.hpp"
 
+#include "AbismalIndex.hpp"
 #include "OptionParser.hpp"
 #include "dna_four_bit.hpp"
 #include "smithlab_os.hpp"
 #include "smithlab_utils.hpp"
 
 #include <config.h>
-#include <omp.h>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -35,24 +35,18 @@
 #include <unordered_set>
 #include <vector>
 
-using std::cerr;
-using std::endl;
-using std::runtime_error;
-using std::string;
-using std::unordered_set;
-using std::vector;
-
 int
 abismalidx(int argc, const char **argv) {
 
   try {
 
-    const string version_str = string("(v") + VERSION + string(")");
-    const string description = "build abismal index " + version_str;
+    const std::string version_str =
+      std::string{"(v"} + VERSION + std::string{")"};
+    const std::string description = "build abismal index " + version_str;
 
-    string target_regions_file;
-    bool VERBOSE = false;
-    size_t n_threads = 1;
+    std::string target_regions_file;
+    bool verbose = false;
+    std::size_t n_threads = 1;
 
     /****************** COMMAND LINE OPTIONS ********************/
     OptionParser opt_parse(strip_path(argv[0]), description,
@@ -61,40 +55,40 @@ abismalidx(int argc, const char **argv) {
     opt_parse.add_opt("targets", 'A', "target regions", false,
                       target_regions_file);
     opt_parse.add_opt("threads", 't', "number of threads", false, n_threads);
-    opt_parse.add_opt("verbose", 'v', "print more run info", false, VERBOSE);
+    opt_parse.add_opt("verbose", 'v', "print more run info", false, verbose);
 
-    vector<string> leftover_args;
+    std::vector<std::string> leftover_args;
     opt_parse.parse(argc, argv, leftover_args);
     if (argc == 1 || opt_parse.help_requested()) {
-      cerr << opt_parse.help_message() << endl;
-      cerr << opt_parse.about_message() << endl;
+      std::cerr << opt_parse.help_message() << std::endl;
+      std::cerr << opt_parse.about_message() << std::endl;
       return EXIT_SUCCESS;
     }
     if (opt_parse.about_requested()) {
-      cerr << opt_parse.about_message() << endl;
+      std::cerr << opt_parse.about_message() << std::endl;
       return EXIT_SUCCESS;
     }
     if (opt_parse.option_missing()) {
-      cerr << opt_parse.option_missing_message() << endl;
+      std::cerr << opt_parse.option_missing_message() << std::endl;
       return EXIT_SUCCESS;
     }
     if (leftover_args.size() != 2) {
-      cerr << opt_parse.help_message() << endl;
+      std::cerr << opt_parse.help_message() << std::endl;
       return EXIT_SUCCESS;
     }
-    const string genome_file = leftover_args.front();
-    const string outfile = leftover_args.back();
+    const std::string genome_file = leftover_args.front();
+    const std::string outfile = leftover_args.back();
     /****************** END COMMAND LINE OPTIONS *****************/
 
-    omp_set_num_threads(n_threads);
-    const double start_time = omp_get_wtime();
-    AbismalIndex::VERBOSE = VERBOSE;
+    const auto start_time{std::chrono::high_resolution_clock::now()};
+    AbismalIndex::set_n_threads(n_threads);
+    AbismalIndex::VERBOSE = verbose;
 
     if (!std::filesystem::exists(genome_file))
-      throw runtime_error("file not found: " + genome_file);
+      throw std::runtime_error("file not found: " + genome_file);
 
     if (!std::filesystem::is_regular_file(genome_file))
-      throw runtime_error("not regular file: " + genome_file);
+      throw std::runtime_error("not regular file: " + genome_file);
 
     /****************** START BUILDING INDEX *************/
     AbismalIndex abismal_index;
@@ -103,42 +97,23 @@ abismalidx(int argc, const char **argv) {
     else
       abismal_index.create_index(genome_file);
 
-    if (VERBOSE)
-      cerr << "[writing abismal index to: " << outfile << "]\n";
+    if (verbose)
+      std::cerr << "[writing abismal index to: " << outfile << "]\n";
 
     abismal_index.write(outfile);
-    if (VERBOSE)
-      cerr << "[total indexing time: " << omp_get_wtime() - start_time << "]"
-           << endl;
+    if (verbose) {
+      const auto stop_time{std::chrono::high_resolution_clock::now()};
+      const auto d = stop_time - start_time;
+      std::cerr
+        << "[total indexing time: "
+        << std::chrono::duration_cast<std::chrono::duration<double>>(d).count()
+        << "]\n";
+    }
     /****************** END BUILDING INDEX *************/
   }
-  catch (const std::runtime_error &e) {
-    cerr << e.what() << endl;
-    return EXIT_FAILURE;
-  }
-  catch (std::bad_alloc &ba) {
-    cerr << "ERROR: could not allocate memory" << endl;
+  catch (const std::exception &e) {
+    std::cerr << e.what() << std::endl;
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;
 }
-
-/*
-  Test strategy:
-  reference genomes:
-  (1) hg38: it's the most common
-  (2) mm39: similar reasoning
-  (3) hs1-t2t: it has different amounts of repeats and Ns
-  (4) TAIR10: it's smaller and might behave differently
-  (5) tRex1: it's very small
-
-  Reads:
-  (1) human: Hodges2011 HSPC / SRR342517
-  (2) mouse: SRR5115694
-  (4) TAIR10: SRR24436012
-  (3) simreads: 10000000 reads, default parameters
-
-  Target regions:
-  (1) Promoters
-  (2) Randomly shuffled promoters
-*/


### PR DESCRIPTION
This affects omp parallel for loops, sections and critical regions, the latter now using scoped lock_guard and mutexes