### PR TITLE
Adding flag to write reads with SAM orientation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,8 +42,6 @@ if ENABLE_SHORT
 AM_CXXFLAGS += -DENABLE_SHORT
 endif
 
-CXXFLAGS = -O3 -DNDEBUG # default has optimization on
-
 noinst_LIBRARIES = libabismal.a
 
 libabismal_a_SOURCES = \

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,13 @@ AM_INIT_AUTOMAKE([subdir-objects foreign])
 AC_CONFIG_MACRO_DIR([m4])
 AC_LANG(C++)
 AC_PROG_CXX
+
+# Set CXXFLAGS only if the user hasn't set them
+AS_IF([test "x$CXXFLAGS_set" != "xset"], [
+  CXXFLAGS="-O3 -DNDEBUG"
+])
+AC_MSG_NOTICE([CXXFLAGS is $CXXFLAGS])
+
 AX_CXX_COMPILE_STDCXX_17([noext], [mandatory])
 
 AM_PROG_AR

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -44,13 +44,13 @@ genome in FASTA format and produces an output file in SAM format. Only reads
 that are mapped uniquely or ambiguously (optional) are reported in the SAM
 output.
 
-abismal can map reads assuming either C>T or G>A conversion in single-end
-reads. Both conversions are also accepted in paired-end mapping, but
-corresponding read pairs are assume to have complementary base
-conversions. The assumption of C>T conversion means Ts in the read are
+abismal can map reads assuming either C-to-T or G-to-A conversion in
+single-end reads. Both conversions are also accepted in paired-end mapping,
+but corresponding read pairs are assume to have complementary base
+conversions. The assumption of C-to-T conversion means Ts in the read are
 considered matches to either Cs or Ts in the reference (in either strand).
-The assumption of G>A conversion means that As in reads are considered matches
-to either Gs or As in the reference.
+The assumption of G-to-A conversion means that As in reads are considered
+matches to either Gs or As in the reference.
 
 absimal was built to map short reads of up to 250 bases. It should
 successfully map reads of size up to 1 million, but because it uses very short
@@ -190,7 +190,7 @@ mate2:
 
 -t NUM-THREADS, -threads NUM-THREADS [default : 1]
 
-number of threads that should be used to map reads. Each thread reads 1000
+Number of threads that should be used to map reads. Each thread reads 1000
 reads in parallel, so increasing this number uses more memory by a few
 kilobytes per additional thread. In most practical cases this should not be
 significantly different than single-thread mapping.
@@ -198,11 +198,11 @@ significantly different than single-thread mapping.
 
 -l MIN-FRAG-VALUE, -min-frag MIN-FRAG-VALUE [default : 32]
 
-(paired-end only) The minimum size a concordant fragment can
-have. There are cases in which concordant pairs can "dovetail", that is, the
-end of the reverse mate can pass the start of the forward mate. Ths parameter
-dictates the minimum size a dovetail read can have while accepting
-concordance. The schematic below depicts what the value of -l represents:
+(paired-end only) The minimum size a concordant fragment can have. There are
+cases in which concordant pairs can "dovetail", that is, the end of the
+reverse mate can pass the start of the forward mate. Ths parameter dictates
+the minimum size a dovetail read can have while accepting concordance. The
+schematic below depicts what the value of -l represents:
 
 ```
                     [==================================>] [FORWARD MATE]
@@ -213,11 +213,11 @@ concordance. The schematic below depicts what the value of -l represents:
 
 -L MAX-FRAG-VALUE, -max-frag MAX-FRAG-VALUE [default : 3000]
 
-(paired-end only) The maximum size a concordant fragment, defined
-as the maximum distance between the genome start (smallest) coordinate of the
-forward mapped mate and the start (largest) coordinate of the reverse mapped
-strand, for a pair to be considered concordant. The schematic below depics how
-L is calculated.
+(paired-end only) The maximum size a concordant fragment, defined as the
+maximum distance between the genome start (smallest) coordinate of the forward
+mapped mate and the start (largest) coordinate of the reverse mapped strand,
+for a pair to be considered concordant. The schematic below depics how L is
+calculated.
 
 ```
 [===============>] [FORWARD MATE]
@@ -243,26 +243,33 @@ in the SAM flags.
 
 -P -pbat
 
-(paired-end only) Assumes the bisulfite conversion of the first
-end to be G>A and the bisulfite conversion of the second end to be C>T.
+(paired-end only) Assumes the bisulfite conversion of the first end to be
+G-to-A and the bisulfite conversion of the second end to be C-to-T.
 
 -R -random-pbat
 
 Maps reads in random PBAT mode.
 
-For single-end mapping, abismal will attempt to map reads assuming C>T
-conversion, then G>A, and keeping the conversion that attains the best
+For single-end mapping, abismal will attempt to map reads assuming C-to-T
+conversion, then G-to-A, and keeping the conversion that attains the best
 alignment score.
 
 For paired-end mapping, abismal will attempt to map reads assuming end 1 has
-C>T conversion and end 2 has G>A conversion. Then it will map the same reads
-assuming end 1 has G>A conversion. The conversion that attains highest sum of
-alignment scores is kept.
+C-to-T conversion and end 2 has G-to-A conversion. Then it will map the same
+reads assuming end 1 has G-to-A conversion. The conversion that attains
+highest sum of alignment scores is kept.
 
 -A -a-rich
 
-(single-end only) Indicates that reads are A-rich.  Mapping
-with this flags assumes that the bisulfite conversion is G>A instead of C>T.
+(single-end only) Indicates that reads are A-rich.  Mapping with this flags
+assumes that the bisulfite conversion is G-to-A instead of C-to-T.
+
+-S -sam-orientation
+
+Report read sequences (the QSEQ in SAM terminology) in the SAM/BAM output file
+using the SAM orientation, which reverse-complements the read if the flags
+indicate it is mapped to the negative strand. The default is to always report
+the read exactly as it appears in the FASTQ input file.
 
 -v -verbose
 
@@ -271,16 +278,16 @@ the percentage of input reads currently processed.
 
 # INPUT FASTQ FORMAT
 
-abismal accepts reads in either FASTQ or FASTQ.GZ formats. The
-FASTQ format represents reads through 4 lines per read.
+abismal accepts reads in either FASTQ or FASTQ.GZ formats. The FASTQ format
+represents reads through 4 lines per read.
 
  - The first line is the read name and has to start with the @ character.
- - The second line is the read itself. Read charcters must beither A,
-   C, G, T or N, in lowercase or uppercase.
+ - The second line is the read itself. Read charcters must beither A, C, G, T
+   or N, in lowercase or uppercase.
  - The third line is ignored. It usually starts with the + character.
- - The fourth line is the Phred quality of each base in the read. It
-   must be the same length as the second line. It is also ignored by
-   the abismal algorithm.
+ - The fourth line is the Phred quality of each base in the read. It must be
+   the same length as the second line. It is also ignored by the abismal
+   algorithm.
 
 An example FASTQ file with one read looks like this:
 
@@ -371,11 +378,11 @@ The last two fields are optional tags that can be used downstream
  - NM: The edit distance (mismatches + insertions + deletions) in the
    alignment between the read and reference
  - CV: The bisulfite letter conversion assumed when mapping the read.  If the
-   read was assumed A-rich (G>A conversion), the value CV:A:A is reported. If
-   the read was assumed T-rich (C>T conversion), then the value CV:A:T is
-   reported. If the -R flag is not set, all reads coming from the same FASTQ
-   file will have the same assumed conversion. If the -R flag is used, this
-   tag provides the conversion used in the reported alignment.
+   read was assumed A-rich (G-to-A conversion), the value CV:A:A is
+   reported. If the read was assumed T-rich (C-to-T conversion), then the
+   value CV:A:T is reported. If the -R flag is not set, all reads coming from
+   the same FASTQ file will have the same assumed conversion. If the -R flag
+   is used, this tag provides the conversion used in the reported alignment.
 
 ## IMPORTANT NOTE ON SEQ READS REPORTED IN THE SAM OUTPUT
 
@@ -387,6 +394,10 @@ consistency with the conversion type reported in the CV tag. This standard
 allows downstream analyses on letter frequencies and conversion types.  Tools
 to reverse-complement the SEQ field and the letter in the CV tag can be used
 if properly formatted SAM files are necessary.
+
+**Update** As of version 3.3.1, `abismal map` includes an option `-S` that
+will do the reverse complement prior to writing the read sequence in the
+SAM/BAM output for any read that maps to the negative strand of the reference.
 
 ## Filtering concordant/discordant pairs in paired-end SAM
 
@@ -507,14 +518,14 @@ the user.
 
 ## Concordant pairs
 
-On paired-end input, we say reads $r_1$ and $r_2$ with lengths $n_1$ and
-$n_2$, respectively, are a corresponding pair are concordant if there exist
-positions $p_1$ and $p_2$ such that
+On paired-end input, we say reads $r1$ and $r2$ with lengths $n1$ and
+$n2$, respectively, are a corresponding pair are concordant if there exist
+positions $p1$ and $p2$ such that
 
-1. $p_1$ is a valid alignment for $r_1$ and $p_2$ is a valid
-alignment for $r_2$
-2. $p_1$ and $p_2$ are in opposite strands of the genome, and
-3. $p_2 - p_1 \geq l$ and $p_2 - p_1 \leq L - n2$.
+1. $p1$ is a valid alignment for $r1$ and $p2$ is a valid alignment for
+$r2$
+2. $p1$ and $p2$ are in opposite strands of the genome, and
+3. $p2 - p1 \geq l$ and $p2 - p1 \leq L - n2$.
 
 This means that the fragment lengths from which the pair originates is at
 least $l$ and at most $L$. The default values of $l$ and $L$ are 32 and 3000,
@@ -551,8 +562,8 @@ The resulting file (out_paired.sam) will contain only concordant pairs.
 
 0 : Success.
 
-1 : Runtime error. When the program, fails, an error message will
-    be shown in STDERR describing the problem encountered.
+1 : Runtime error. When the program, fails, an error message will be shown in
+    STDERR describing the problem encountered.
 
 # REPORTING BUGS
 

--- a/docs/abismal.1
+++ b/docs/abismal.1
@@ -49,15 +49,15 @@ format.
 Only reads that are mapped uniquely or ambiguously (optional) are
 reported in the SAM output.
 .PP
-abismal can map reads assuming either C>T or G>A conversion in
+abismal can map reads assuming either C-to-T or G-to-A conversion in
 single-end reads.
 Both conversions are also accepted in paired-end mapping, but
 corresponding read pairs are assume to have complementary base
 conversions.
-The assumption of C>T conversion means Ts in the read are considered
+The assumption of C-to-T conversion means Ts in the read are considered
 matches to either Cs or Ts in the reference (in either strand).
-The assumption of G>A conversion means that As in reads are considered
-matches to either Gs or As in the reference.
+The assumption of G-to-A conversion means that As in reads are
+considered matches to either Gs or As in the reference.
 .PP
 absimal was built to map short reads of up to 250 bases.
 It should successfully map reads of size up to 1 million, but because it
@@ -213,7 +213,7 @@ mate2:
 .PP
 -t NUM-THREADS, -threads NUM-THREADS [default : 1]
 .PP
-number of threads that should be used to map reads.
+Number of threads that should be used to map reads.
 Each thread reads 1000 reads in parallel, so increasing this number uses
 more memory by a few kilobytes per additional thread.
 In most practical cases this should not be significantly different than
@@ -274,26 +274,34 @@ flags.
 -P -pbat
 .PP
 (paired-end only) Assumes the bisulfite conversion of the first end to
-be G>A and the bisulfite conversion of the second end to be C>T.
+be G-to-A and the bisulfite conversion of the second end to be C-to-T.
 .PP
 -R -random-pbat
 .PP
 Maps reads in random PBAT mode.
 .PP
-For single-end mapping, abismal will attempt to map reads assuming C>T
-conversion, then G>A, and keeping the conversion that attains the best
-alignment score.
+For single-end mapping, abismal will attempt to map reads assuming
+C-to-T conversion, then G-to-A, and keeping the conversion that attains
+the best alignment score.
 .PP
 For paired-end mapping, abismal will attempt to map reads assuming end 1
-has C>T conversion and end 2 has G>A conversion.
-Then it will map the same reads assuming end 1 has G>A conversion.
+has C-to-T conversion and end 2 has G-to-A conversion.
+Then it will map the same reads assuming end 1 has G-to-A conversion.
 The conversion that attains highest sum of alignment scores is kept.
 .PP
 -A -a-rich
 .PP
 (single-end only) Indicates that reads are A-rich.
-Mapping with this flags assumes that the bisulfite conversion is G>A
-instead of C>T.
+Mapping with this flags assumes that the bisulfite conversion is G-to-A
+instead of C-to-T.
+.PP
+-S -sam-orientation
+.PP
+Report read sequences (the QSEQ in SAM terminology) in the SAM/BAM
+output file using the SAM orientation, which reverse-complements the
+read if the flags indicate it is mapped to the negative strand.
+The default is to always report the read exactly as it appears in the
+FASTQ input file.
 .PP
 -v -verbose
 .PP
@@ -430,10 +438,10 @@ NM: The edit distance (mismatches + insertions + deletions) in the
 alignment between the read and reference
 .IP \[bu] 2
 CV: The bisulfite letter conversion assumed when mapping the read.
-If the read was assumed A-rich (G>A conversion), the value CV:A:A is
+If the read was assumed A-rich (G-to-A conversion), the value CV:A:A is
 reported.
-If the read was assumed T-rich (C>T conversion), then the value CV:A:T
-is reported.
+If the read was assumed T-rich (C-to-T conversion), then the value
+CV:A:T is reported.
 If the -R flag is not set, all reads coming from the same FASTQ file
 will have the same assumed conversion.
 If the -R flag is used, this tag provides the conversion used in the
@@ -451,6 +459,11 @@ This standard allows downstream analyses on letter frequencies and
 conversion types.
 Tools to reverse-complement the SEQ field and the letter in the CV tag
 can be used if properly formatted SAM files are necessary.
+.PP
+\f[B]Update\f[R] As of version 3.3.1, \f[C]abismal map\f[R] includes an
+option \f[C]-S\f[R] that will do the reverse complement prior to writing
+the read sequence in the SAM/BAM output for any read that maps to the
+negative strand of the reference.
 .SS Filtering concordant/discordant pairs in paired-end SAM
 .PP
 In paired-end mapping, abismal will try to mate concordant pairs and
@@ -591,20 +604,19 @@ Some application-specific cases may require more or less acceptable
 error, so this parameter can be adjusted by the user.
 .SS Concordant pairs
 .PP
-On paired-end input, we say reads \f[I]r\f[R]~1~ and \f[I]r\f[R]~2~ with
-lengths \f[I]n\f[R]~1~ and \f[I]n\f[R]~2~, respectively, are a
-corresponding pair are concordant if there exist positions
-\f[I]p\f[R]~1~ and \f[I]p\f[R]~2~ such that
+On paired-end input, we say reads \f[I]r\f[R]1 and \f[I]r\f[R]2 with
+lengths \f[I]n\f[R]1 and \f[I]n\f[R]2, respectively, are a corresponding
+pair are concordant if there exist positions \f[I]p\f[R]1 and
+\f[I]p\f[R]2 such that
 .IP "1." 3
-\f[I]p\f[R]~1~ is a valid alignment for \f[I]r\f[R]~1~ and
-\f[I]p\f[R]~2~ is a valid alignment for \f[I]r\f[R]~2~
+\f[I]p\f[R]1 is a valid alignment for \f[I]r\f[R]1 and \f[I]p\f[R]2 is a
+valid alignment for \f[I]r\f[R]2
 .IP "2." 3
-\f[I]p\f[R]~1~ and \f[I]p\f[R]~2~ are in opposite strands of the genome,
-and
+\f[I]p\f[R]1 and \f[I]p\f[R]2 are in opposite strands of the genome, and
 .IP "3." 3
-\f[I]p\f[R]~2~\[u2005]\[mi]\[u2005]\f[I]p\f[R]~1~\[u2004]\[>=]\[u2004]\f[I]l\f[R]
+\f[I]p\f[R]2\[u2005]\[mi]\[u2005]\f[I]p\f[R]1\[u2004]\[>=]\[u2004]\f[I]l\f[R]
 and
-\f[I]p\f[R]~2~\[u2005]\[mi]\[u2005]\f[I]p\f[R]~1~\[u2004]\[<=]\[u2004]\f[I]L\f[R]\[u2005]\[mi]\[u2005]\f[I]n\f[R]2.
+\f[I]p\f[R]2\[u2005]\[mi]\[u2005]\f[I]p\f[R]1\[u2004]\[<=]\[u2004]\f[I]L\f[R]\[u2005]\[mi]\[u2005]\f[I]n\f[R]2.
 .PP
 This means that the fragment lengths from which the pair originates is
 at least \f[I]l\f[R] and at most \f[I]L\f[R].

--- a/docs/abismal.html
+++ b/docs/abismal.html
@@ -35,7 +35,7 @@ abismal map -i ref.idx -o out.sam [-s out.stats] reads_1.fq reads_2.fq</code></p
 <pre><code>abismal idx ref.fa ref.idx</code></pre>
 <h1 id="description">DESCRIPTION</h1>
 <p>abismal maps short bisulfite sequencing reads in FASTQ format to a reference genome in FASTA format and produces an output file in SAM format. Only reads that are mapped uniquely or ambiguously (optional) are reported in the SAM output.</p>
-<p>abismal can map reads assuming either C&gt;T or G&gt;A conversion in single-end reads. Both conversions are also accepted in paired-end mapping, but corresponding read pairs are assume to have complementary base conversions. The assumption of C&gt;T conversion means Ts in the read are considered matches to either Cs or Ts in the reference (in either strand). The assumption of G&gt;A conversion means that As in reads are considered matches to either Gs or As in the reference.</p>
+<p>abismal can map reads assuming either C-to-T or G-to-A conversion in single-end reads. Both conversions are also accepted in paired-end mapping, but corresponding read pairs are assume to have complementary base conversions. The assumption of C-to-T conversion means Ts in the read are considered matches to either Cs or Ts in the reference (in either strand). The assumption of G-to-A conversion means that As in reads are considered matches to either Gs or As in the reference.</p>
 <p>absimal was built to map short reads of up to 250 bases. It should successfully map reads of size up to 1 million, but because it uses very short seeds for filtration, the mapping time will increase substantially.</p>
 <h1 id="quick-installation">QUICK INSTALLATION</h1>
 <p>Run the following commands to install abismal</p>
@@ -128,7 +128,7 @@ mate2:
     percent_unmapped: 58.8215
     percent_skipped: 0</code></pre>
 <p>-t NUM-THREADS, -threads NUM-THREADS [default : 1]</p>
-<p>number of threads that should be used to map reads. Each thread reads 1000 reads in parallel, so increasing this number uses more memory by a few kilobytes per additional thread. In most practical cases this should not be significantly different than single-thread mapping.</p>
+<p>Number of threads that should be used to map reads. Each thread reads 1000 reads in parallel, so increasing this number uses more memory by a few kilobytes per additional thread. In most practical cases this should not be significantly different than single-thread mapping.</p>
 <p>-l MIN-FRAG-VALUE, -min-frag MIN-FRAG-VALUE [default : 32]</p>
 <p>(paired-end only) The minimum size a concordant fragment can have. There are cases in which concordant pairs can “dovetail”, that is, the end of the reverse mate can pass the start of the forward mate. Ths parameter dictates the minimum size a dovetail read can have while accepting concordance. The schematic below depicts what the value of -l represents:</p>
 <pre><code>                    [==================================&gt;] [FORWARD MATE]
@@ -144,13 +144,15 @@ mate2:
 <p>-a -ambig</p>
 <p>If this flag is provided, abismal will report a random location to reads that mapped ambiguously. These reads can be identified by the presence of bit 0x100 in the SAM flags.</p>
 <p>-P -pbat</p>
-<p>(paired-end only) Assumes the bisulfite conversion of the first end to be G&gt;A and the bisulfite conversion of the second end to be C&gt;T.</p>
+<p>(paired-end only) Assumes the bisulfite conversion of the first end to be G-to-A and the bisulfite conversion of the second end to be C-to-T.</p>
 <p>-R -random-pbat</p>
 <p>Maps reads in random PBAT mode.</p>
-<p>For single-end mapping, abismal will attempt to map reads assuming C&gt;T conversion, then G&gt;A, and keeping the conversion that attains the best alignment score.</p>
-<p>For paired-end mapping, abismal will attempt to map reads assuming end 1 has C&gt;T conversion and end 2 has G&gt;A conversion. Then it will map the same reads assuming end 1 has G&gt;A conversion. The conversion that attains highest sum of alignment scores is kept.</p>
+<p>For single-end mapping, abismal will attempt to map reads assuming C-to-T conversion, then G-to-A, and keeping the conversion that attains the best alignment score.</p>
+<p>For paired-end mapping, abismal will attempt to map reads assuming end 1 has C-to-T conversion and end 2 has G-to-A conversion. Then it will map the same reads assuming end 1 has G-to-A conversion. The conversion that attains highest sum of alignment scores is kept.</p>
 <p>-A -a-rich</p>
-<p>(single-end only) Indicates that reads are A-rich. Mapping with this flags assumes that the bisulfite conversion is G&gt;A instead of C&gt;T.</p>
+<p>(single-end only) Indicates that reads are A-rich. Mapping with this flags assumes that the bisulfite conversion is G-to-A instead of C-to-T.</p>
+<p>-S -sam-orientation</p>
+<p>Report read sequences (the QSEQ in SAM terminology) in the SAM/BAM output file using the SAM orientation, which reverse-complements the read if the flags indicate it is mapped to the negative strand. The default is to always report the read exactly as it appears in the FASTQ input file.</p>
 <p>-v -verbose</p>
 <p>Prints more run info on the mapping progress, including a progress bar showing the percentage of input reads currently processed.</p>
 <h1 id="input-fastq-format">INPUT FASTQ FORMAT</h1>
@@ -199,10 +201,11 @@ IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII</code></pre>
 <p>The last two fields are optional tags that can be used downstream</p>
 <ul>
 <li>NM: The edit distance (mismatches + insertions + deletions) in the alignment between the read and reference</li>
-<li>CV: The bisulfite letter conversion assumed when mapping the read. If the read was assumed A-rich (G&gt;A conversion), the value CV:A:A is reported. If the read was assumed T-rich (C&gt;T conversion), then the value CV:A:T is reported. If the -R flag is not set, all reads coming from the same FASTQ file will have the same assumed conversion. If the -R flag is used, this tag provides the conversion used in the reported alignment.</li>
+<li>CV: The bisulfite letter conversion assumed when mapping the read. If the read was assumed A-rich (G-to-A conversion), the value CV:A:A is reported. If the read was assumed T-rich (C-to-T conversion), then the value CV:A:T is reported. If the -R flag is not set, all reads coming from the same FASTQ file will have the same assumed conversion. If the -R flag is used, this tag provides the conversion used in the reported alignment.</li>
 </ul>
 <h2 id="important-note-on-seq-reads-reported-in-the-sam-output">IMPORTANT NOTE ON SEQ READS REPORTED IN THE SAM OUTPUT</h2>
 <p>In a strict sense, the SEQ field reported by abismal does not comply with the SAM standard. Properly formatted SAM files reverse-complement reads that map to the reverse strand of the reference genome, whereas abismal reports reads identical to the input FASTQ. This is done deliberately to maintain consistency with the conversion type reported in the CV tag. This standard allows downstream analyses on letter frequencies and conversion types. Tools to reverse-complement the SEQ field and the letter in the CV tag can be used if properly formatted SAM files are necessary.</p>
+<p><strong>Update</strong> As of version 3.3.1, <code>abismal map</code> includes an option <code>-S</code> that will do the reverse complement prior to writing the read sequence in the SAM/BAM output for any read that maps to the negative strand of the reference.</p>
 <h2 id="filtering-concordantdiscordant-pairs-in-paired-end-sam">Filtering concordant/discordant pairs in paired-end SAM</h2>
 <p>In paired-end mapping, abismal will try to mate concordant pairs and find pairs whose sum of edit distances is below the user-defined cut-off (set to 10% of the mapped read length by default). If it cannot find such concordant pair (either due to ambiguity or low alignment score), abismal will map each end as single-end reads and report locations with sufficiently high similarity. In many cases, one may want to only keep concordant pairs, or even isolate discordant pairs to analyze their sequence patterns, mapping quality, etc.</p>
 <p>To isolate concordant pairs from paired-end output <code>out.sam</code>, use the following awk script, which isolates the SAM header and reads with an equal (=) symbol in the RNEXT field (reserved only for concordant pairs).</p>
@@ -232,11 +235,11 @@ IIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIIII</code></pre>
 <h2 id="valid-alignments">Valid alignments</h2>
 <p>We say a candidate is a valid alignment if the edit distance is at most a fraction m of the read length. The acceptable fraction can be set through the -m or -max-distance flag in <a href="#options">options</a>. Some application-specific cases may require more or less acceptable error, so this parameter can be adjusted by the user.</p>
 <h2 id="concordant-pairs">Concordant pairs</h2>
-<p>On paired-end input, we say reads <span class="math inline"><em>r</em><sub>1</sub></span> and <span class="math inline"><em>r</em><sub>2</sub></span> with lengths <span class="math inline"><em>n</em><sub>1</sub></span> and <span class="math inline"><em>n</em><sub>2</sub></span>, respectively, are a corresponding pair are concordant if there exist positions <span class="math inline"><em>p</em><sub>1</sub></span> and <span class="math inline"><em>p</em><sub>2</sub></span> such that</p>
+<p>On paired-end input, we say reads <span class="math inline"><em>r</em>1</span> and <span class="math inline"><em>r</em>2</span> with lengths <span class="math inline"><em>n</em>1</span> and <span class="math inline"><em>n</em>2</span>, respectively, are a corresponding pair are concordant if there exist positions <span class="math inline"><em>p</em>1</span> and <span class="math inline"><em>p</em>2</span> such that</p>
 <ol type="1">
-<li><span class="math inline"><em>p</em><sub>1</sub></span> is a valid alignment for <span class="math inline"><em>r</em><sub>1</sub></span> and <span class="math inline"><em>p</em><sub>2</sub></span> is a valid alignment for <span class="math inline"><em>r</em><sub>2</sub></span></li>
-<li><span class="math inline"><em>p</em><sub>1</sub></span> and <span class="math inline"><em>p</em><sub>2</sub></span> are in opposite strands of the genome, and</li>
-<li><span class="math inline"><em>p</em><sub>2</sub> − <em>p</em><sub>1</sub> ≥ <em>l</em></span> and <span class="math inline"><em>p</em><sub>2</sub> − <em>p</em><sub>1</sub> ≤ <em>L</em> − <em>n</em>2</span>.</li>
+<li><span class="math inline"><em>p</em>1</span> is a valid alignment for <span class="math inline"><em>r</em>1</span> and <span class="math inline"><em>p</em>2</span> is a valid alignment for <span class="math inline"><em>r</em>2</span></li>
+<li><span class="math inline"><em>p</em>1</span> and <span class="math inline"><em>p</em>2</span> are in opposite strands of the genome, and</li>
+<li><span class="math inline"><em>p</em>2 − <em>p</em>1 ≥ <em>l</em></span> and <span class="math inline"><em>p</em>2 − <em>p</em>1 ≤ <em>L</em> − <em>n</em>2</span>.</li>
 </ol>
 <p>This means that the fragment lengths from which the pair originates is at least <span class="math inline"><em>l</em></span> and at most <span class="math inline"><em>L</em></span>. The default values of <span class="math inline"><em>l</em></span> and <span class="math inline"><em>L</em></span> are 32 and 3000, respectively, and can be set by the <code>-l</code> and <code>-L</code> flags. Those are conservative values that cover most of the current protocols. We will incorporate automatic calculations of these values in the future based on the first high-quality read pairs that are mapped.</p>
 <h2 id="discordant-pairs">Discordant pairs</h2>

--- a/src/AbismalAlign.hpp
+++ b/src/AbismalAlign.hpp
@@ -34,7 +34,7 @@
 // subsequence.
 typedef int16_t score_t;
 typedef genome_four_bit_itr genome_iterator;
-typedef std::vector<uint32_t> bam_cigar_t;
+typedef std::vector<std::uint32_t> bam_cigar_t;
 
 static inline score_t
 count_deletions(const bam_cigar_t &cigar) {
@@ -63,18 +63,19 @@ static const score_t indel = -4;
 static const std::array<score_t, 2> score_lookup = {match, mismatch};
 
 inline score_t
-default_score(const uint32_t len, const score_t diffs) {
+default_score(const std::uint32_t len, const score_t diffs) {
   return match * (len - diffs) + mismatch * diffs;
 }
 
 inline score_t
-mismatch_score(const uint8_t q_base, const uint8_t t_base) {
+mismatch_score(const std::uint8_t q_base, const std::uint8_t t_base) {
   return score_lookup[(q_base & t_base) == 0];
 }
 
 // edit distance as a function of aln_score and len
 inline score_t
-edit_distance(const score_t scr, const uint32_t len, const bam_cigar_t &cigar) {
+edit_distance(const score_t scr, const std::uint32_t len,
+              const bam_cigar_t &cigar) {
   if (scr == 0)
     return len;
   const score_t ins = count_insertions(cigar);
@@ -90,17 +91,17 @@ edit_distance(const score_t scr, const uint32_t len, const bam_cigar_t &cigar) {
 }
 
 inline score_t
-best_single_score(const uint32_t readlen) {
+best_single_score(const std::uint32_t readlen) {
   return match * readlen;
 }
 
 inline score_t
-best_pair_score(const uint32_t readlen1, const uint32_t readlen2) {
+best_pair_score(const std::uint32_t readlen1, const std::uint32_t readlen2) {
   return best_single_score(readlen1) + best_single_score(readlen2);
 }
 }  // namespace simple_aln
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t),
+template <score_t (*scr_fun)(const std::uint8_t, const std::uint8_t),
           score_t indel_pen = -1>
 struct AbismalAlign {
   explicit AbismalAlign(const genome_iterator &target_start) :
@@ -109,72 +110,75 @@ struct AbismalAlign {
   template <const bool do_traceback>
   score_t
   align(const score_t diffs, const score_t max_diffs,
-        const std::vector<uint8_t> &query, const uint32_t t_pos);
+        const std::vector<std::uint8_t> &query, const std::uint32_t t_pos);
 
   void
   build_cigar_len_and_pos(const score_t diffs, const score_t max_diffs,
-                          bam_cigar_t &cigar, uint32_t &len, uint32_t &t_pos);
+                          bam_cigar_t &cigar, std::uint32_t &len,
+                          std::uint32_t &t_pos);
 
   void
-  reset(const uint32_t max_read_length);
+  reset(const std::uint32_t max_read_length);
 
   std::vector<score_t> table;
   std::vector<int8_t> traceback;
   const genome_iterator target;
-  const size_t bw;
+  const std::size_t bw{};
 
   // these are kept because they are needed in both
   // align and build_cigar
-  uint16_t q_sz_max;
-  uint16_t q_sz;
+  std::uint16_t q_sz_max{};
+  std::uint16_t q_sz{};
 
-  static const size_t max_off_diag = 30;
+  static const std::size_t max_off_diag = 30;
 };
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
+template <score_t (*scr_fun)(const std::uint8_t, const std::uint8_t),
+          score_t indel_pen>
 void
 AbismalAlign<scr_fun, indel_pen>::reset(
-  const uint32_t max_read_length) {  // uses cigar
+  const std::uint32_t max_read_length) {  // uses cigar
   q_sz_max = max_read_length;
 
   // size of alignment matrix and traceback matrix is maximum query
   // length times the width of the band around the diagonal
-  const size_t n_cells = (q_sz_max + bw) * bw;
+  const std::size_t n_cells = (q_sz_max + bw) * bw;
   table.resize(n_cells);
   traceback.resize(n_cells, -1);  // ADS: -1 no meaning for traceback
 }
 
 // for making the CIGAR string
-static const uint8_t left_symbol = ABISMAL_BAM_CINS;             // I
-static const uint8_t above_symbol = ABISMAL_BAM_CDEL;            // D
-static const uint8_t diag_symbol = ABISMAL_BAM_CMATCH;           // M
-static const uint8_t soft_clip_symbol = ABISMAL_BAM_CSOFT_CLIP;  // S
+static const std::uint8_t left_symbol = ABISMAL_BAM_CINS;             // I
+static const std::uint8_t above_symbol = ABISMAL_BAM_CDEL;            // D
+static const std::uint8_t diag_symbol = ABISMAL_BAM_CMATCH;           // M
+static const std::uint8_t soft_clip_symbol = ABISMAL_BAM_CSOFT_CLIP;  // S
 
 static inline bool  // consumes reference
-is_deletion(const uint8_t c) {
+is_deletion(const std::uint8_t c) {
   return c == above_symbol;
 }
 
 static inline bool  // does not consume reference
-is_insertion(const uint8_t c) {
+is_insertion(const std::uint8_t c) {
   return c == left_symbol;
 }
 
 static inline void
-get_traceback(const size_t n_col, const std::vector<score_t> &table,
+get_traceback(const std::size_t n_col, const std::vector<score_t> &table,
               const std::vector<int8_t> &traceback,
-              std::vector<uint32_t> &cigar, size_t &the_row, size_t &the_col) {
+              std::vector<std::uint32_t> &cigar, std::size_t &the_row,
+              std::size_t &the_col) {
   int8_t prev_arrow = traceback[the_row * n_col + the_col];
-  const bool is_del = is_deletion(prev_arrow);
-  const bool is_ins = is_insertion(prev_arrow);
+  bool is_del = is_deletion(prev_arrow);
+  bool is_ins = is_insertion(prev_arrow);
   the_row -= !is_ins;
   the_col -= is_ins;
   the_col += is_del;  // ADS: straight up IS diagonal!
-  uint32_t n = 1;
+  std::uint32_t n = 1;
   while (table[the_row * n_col + the_col] > 0) {
     const int8_t arrow = traceback[the_row * n_col + the_col];
-    const bool is_del = is_deletion(arrow);
-    const bool is_ins = is_insertion(arrow);
+    is_del = is_deletion(arrow);
+    is_ins = is_insertion(arrow);
     the_row -= !is_ins;
     the_col -= is_ins;
     the_col += is_del;
@@ -201,11 +205,12 @@ min16(const T a, const T b) {
 }
 
 static score_t
-get_best_score(const std::vector<score_t> &table, const size_t n_cells,
-               const size_t n_col, size_t &best_i, size_t &best_j) {
+get_best_score(const std::vector<score_t> &table, const std::size_t n_cells,
+               const std::size_t n_col, std::size_t &best_i,
+               std::size_t &best_j) {
   auto best_cell_itr =
     std::max_element(std::begin(table), std::begin(table) + n_cells);
-  const size_t best_cell = std::distance(std::begin(table), best_cell_itr);
+  const std::size_t best_cell = std::distance(std::begin(table), best_cell_itr);
   best_i = best_cell / n_col;
   best_j = best_cell % n_col;
   return *best_cell_itr;
@@ -217,11 +222,11 @@ get_best_score(const std::vector<score_t> &table, const size_t n_cells,
 // below. Using the __attribute__ helps with GCC, and it should be
 // ignored if not supported.
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), class T,
+template <score_t (*scr_fun)(const std::uint8_t, const std::uint8_t), class T,
           class QueryConstItr>
 __attribute__((optimize("no-tree-loop-vectorize"))) void
 from_diag(T next_row, const T next_row_end, T cur_row, QueryConstItr query_seq,
-          uint8_t ref_base) {
+          std::uint8_t ref_base) {
   while (next_row != next_row_end) {
     const score_t score = scr_fun(*query_seq++, ref_base) + *cur_row++;
     max16(*next_row++, score);
@@ -249,11 +254,11 @@ from_left(T left_itr, T target, const T target_end) {
 }
 
 /********* SAME FUNCTIONS AS ABOVE BUT WITH TRACEBACK ********/
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), class T,
+template <score_t (*scr_fun)(const std::uint8_t, const std::uint8_t), class T,
           class QueryConstItr, class U>
 __attribute__((optimize("no-tree-loop-vectorize"))) void
 from_diag(T next_row, const T next_row_end, T cur_row, QueryConstItr query_seq,
-          uint8_t ref_base, U traceback) {
+          std::uint8_t ref_base, U traceback) {
   while (next_row != next_row_end) {
     const score_t score = scr_fun(*query_seq, ref_base) + *cur_row;
     max16(*next_row, score);
@@ -292,32 +297,33 @@ from_left(T left_itr, T target, const T target_end, U traceback) {
 }
 
 inline void
-make_default_cigar(const uint32_t len, std::string &cigar) {
+make_default_cigar(const std::uint32_t len, std::string &cigar) {
   cigar = std::to_string(len) + 'M';
 }
 
 inline void
-make_default_cigar(const uint32_t len, bam_cigar_t &cigar) {
+make_default_cigar(const std::uint32_t len, bam_cigar_t &cigar) {
   // ADS: below is = { abismal_bam_cigar_gen(len, 0)};
   cigar = {(len << ABISMAL_BAM_CIGAR_SHIFT)};
 }
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
+template <score_t (*scr_fun)(const std::uint8_t, const std::uint8_t),
+          score_t indel_pen>
 template <const bool do_traceback>
 score_t
 AbismalAlign<scr_fun, indel_pen>::align(const score_t diffs,
                                         const score_t max_diffs,
-                                        const std::vector<uint8_t> &qseq,
-                                        const uint32_t t_pos) {
+                                        const std::vector<std::uint8_t> &qseq,
+                                        const std::uint32_t t_pos) {
   q_sz = qseq.size();
   // edge case: diffs = 0 so alignment is "trivial"
   if (diffs == 0)
     return simple_aln::best_single_score(q_sz);
 
   // if diffs is small bw can be reduced
-  const size_t bandwidth =
-    min16(bw, static_cast<size_t>(2 * min16(diffs, max_diffs) + 1));
-  const size_t n_cells = (q_sz + bandwidth) * bandwidth;
+  const std::size_t bandwidth =
+    min16(bw, static_cast<std::size_t>(2 * min16(diffs, max_diffs) + 1));
+  const std::size_t n_cells = (q_sz + bandwidth) * bandwidth;
 
   std::fill(std::begin(table), std::begin(table) + n_cells, 0);
   if (do_traceback)
@@ -325,8 +331,8 @@ AbismalAlign<scr_fun, indel_pen>::align(const score_t diffs,
 
   // GS: non-negative because of padding. The mapper
   // must ensure t_pos is large enough when calling the function
-  const size_t t_beg = t_pos - ((bandwidth - 1) / 2);
-  const size_t t_shift = q_sz + bandwidth;
+  const std::size_t t_beg = t_pos - ((bandwidth - 1) / 2);
+  const std::size_t t_shift = q_sz + bandwidth;
 
   // points to relevant reference sequence positions
   genome_iterator t_itr = target + t_beg;
@@ -337,9 +343,9 @@ AbismalAlign<scr_fun, indel_pen>::align(const score_t diffs,
   auto prev(std::begin(table));
   auto cur(prev);
 
-  for (size_t i = 1; i < t_shift; ++i) {
-    const size_t left = (i < bandwidth ? bandwidth - i : 0);
-    const size_t right = min16(bandwidth, t_shift - i);
+  for (std::size_t i = 1; i < t_shift; ++i) {
+    const std::size_t left = (i < bandwidth ? bandwidth - i : 0);
+    const std::size_t right = min16(bandwidth, t_shift - i);
 
     cur += bandwidth;  // next row in aln matrix
     if (do_traceback) {
@@ -363,20 +369,21 @@ AbismalAlign<scr_fun, indel_pen>::align(const score_t diffs,
   }
 
   // locate the end of the alignment as max score
-  size_t the_row = 0, the_col = 0;
+  std::size_t the_row = 0, the_col = 0;
   return get_best_score(table, n_cells, bandwidth, the_row, the_col);
 }
 
-template <score_t (*scr_fun)(const uint8_t, const uint8_t), score_t indel_pen>
+template <score_t (*scr_fun)(const std::uint8_t, const std::uint8_t),
+          score_t indel_pen>
 void
 AbismalAlign<scr_fun, indel_pen>::build_cigar_len_and_pos(  // uses cigar
   const score_t diffs, const score_t max_diffs, bam_cigar_t &cigar,
-  uint32_t &len, uint32_t &t_pos) {
+  std::uint32_t &len, std::uint32_t &t_pos) {
   // locate the end of the alignment as max score
-  const size_t bandwidth =
-    min16(bw, static_cast<size_t>(2 * min16(diffs, max_diffs) + 1));
-  const size_t n_cells = (q_sz + bandwidth) * bandwidth;
-  size_t the_row = 0, the_col = 0;
+  const std::size_t bandwidth =
+    min16(bw, static_cast<std::size_t>(2 * min16(diffs, max_diffs) + 1));
+  const std::size_t n_cells = (q_sz + bandwidth) * bandwidth;
+  std::size_t the_row = 0, the_col = 0;
   const score_t r = get_best_score(table, n_cells, bandwidth, the_row, the_col);
 
   // GS: unlikely, but possible, case where the score = 0, which
@@ -389,7 +396,7 @@ AbismalAlign<scr_fun, indel_pen>::build_cigar_len_and_pos(  // uses cigar
   }
 
   // soft clip "S" at the start of the (reverse) uncompressed cigar
-  const size_t soft_clip_bottom =
+  const std::size_t soft_clip_bottom =
     (q_sz + (bandwidth - 1)) - (the_row + the_col);
 
   // run traceback, the_row and the_col now point to start of tb
@@ -397,7 +404,7 @@ AbismalAlign<scr_fun, indel_pen>::build_cigar_len_and_pos(  // uses cigar
   get_traceback(bandwidth, table, traceback, cigar, the_row, the_col);
 
   // soft clip "S" at the end of the (reverse) uncompressed cigar
-  const size_t soft_clip_top = (the_row + the_col) - (bandwidth - 1);
+  const std::size_t soft_clip_top = (the_row + the_col) - (bandwidth - 1);
 
   // if there is any soft clip at the top, now append it
   if (soft_clip_top > 0)
@@ -415,7 +422,7 @@ AbismalAlign<scr_fun, indel_pen>::build_cigar_len_and_pos(  // uses cigar
   len = q_sz - soft_clip_bottom - soft_clip_top;
 
   // ADS: should have documented this better the first time around...
-  const size_t t_beg = t_pos - ((bandwidth - 1) / 2);
+  const std::size_t t_beg = t_pos - ((bandwidth - 1) / 2);
   t_pos = t_beg + the_row;
 }
 

--- a/src/AbismalIndex.hpp
+++ b/src/AbismalIndex.hpp
@@ -34,7 +34,7 @@
 #include "dna_four_bit.hpp"
 #include "smithlab_utils.hpp"
 
-using element_t = size_t;
+using element_t = std::size_t;
 using Genome = std::vector<element_t>;
 using two_letter_t = bool;
 using three_letter_t = uint8_t;
@@ -61,36 +61,36 @@ struct random_base_generator {
 
 private:
   random_base_generator() {}
-  uint32_t x{1};
+  std::uint32_t x{1};
 };
 
 static random_base_generator &random_base = random_base_generator::init();
 
 namespace seed {
 // number of positions in the hashed portion of the seed
-static const uint32_t key_weight = 25u;
-static const uint32_t key_weight_three = 16u;
+static const std::uint32_t key_weight = 25u;
+static const std::uint32_t key_weight_three = 16u;
 
 // window in which we select the best k-mer. The longer it is,
 // the longer the minimum read length that guarantees an exact
 // match will be mapped
 #ifdef ENABLE_SHORT
-static const uint32_t window_size = 12u;
+static const std::uint32_t window_size = 12u;
 #else
-static const uint32_t window_size = 20u;
+static const std::uint32_t window_size = 20u;
 #endif
 
 // number of positions to sort within buckets
-static const uint32_t n_sorting_positions = 256u;
+static const std::uint32_t n_sorting_positions = 256u;
 
-static const size_t hash_mask = (1ull << seed::key_weight) - 1;
-static const size_t hash_mask_three = pow(3, key_weight_three);
+static const std::size_t hash_mask = (1ull << seed::key_weight) - 1;
+static const std::size_t hash_mask_three = pow(3, key_weight_three);
 
 // the purpose of padding the left and right ends of the
 // concatenated genome is so that later we can avoid having to check
 // the (unlikely) case that a read maps partly off either end of the
 // genome.
-static const size_t padding_size = std::numeric_limits<int16_t>::max();
+static const std::size_t padding_size = std::numeric_limits<int16_t>::max();
 
 void
 read(FILE *in);
@@ -100,18 +100,19 @@ write(FILE *out);
 
 struct ChromLookup {
   std::vector<std::string> names;
-  std::vector<uint32_t> starts;
+  std::vector<std::uint32_t> starts;
 
   void
-  get_chrom_idx_and_offset(const uint32_t pos, uint32_t &chrom_idx,
-                           uint32_t &offset) const;
+  get_chrom_idx_and_offset(const std::uint32_t pos, std::uint32_t &chrom_idx,
+                           std::uint32_t &offset) const;
   bool
-  get_chrom_idx_and_offset(const uint32_t pos, const uint32_t readlen,
-                           uint32_t &chrom_idx, uint32_t &offset) const;
+  get_chrom_idx_and_offset(const std::uint32_t pos, const std::uint32_t readlen,
+                           std::uint32_t &chrom_idx,
+                           std::uint32_t &offset) const;
 
-  uint32_t
-  get_pos(const std::string &chrom, const uint32_t offset) const;
-  uint32_t
+  std::uint32_t
+  get_pos(const std::string &chrom, const std::uint32_t offset) const;
+  std::uint32_t
   get_genome_size() const {
     return starts.back();
   }
@@ -135,7 +136,7 @@ struct ChromLookup {
 };
 
 void
-load_genome(const std::string &genome_file, std::vector<uint8_t> &genome,
+load_genome(const std::string &genome_file, std::vector<std::uint8_t> &genome,
             ChromLookup &cl);
 
 void
@@ -150,30 +151,30 @@ struct AbismalIndex {
 
   static bool VERBOSE;
 
-  static const uint32_t max_n_count = 256ul;
+  static const std::uint32_t max_n_count = 256ul;
   static std::size_t n_threads_global;
 
-  uint32_t max_candidates{100u};
+  std::uint32_t max_candidates{100u};
 
-  size_t counter_size;        // number of kmers indexed
-  size_t counter_size_three;  // number of kmers indexed
+  std::size_t counter_size{};        // number of kmers indexed
+  std::size_t counter_size_three{};  // number of kmers indexed
 
-  size_t index_size;        // number of genome positions indexed
-  size_t index_size_three;  // number of genome positions indexed
+  std::size_t index_size{};        // number of genome positions indexed
+  std::size_t index_size_three{};  // number of genome positions indexed
 
-  std::vector<uint32_t> index;    // genome positions for each k-mer
-  std::vector<uint32_t> index_t;  // genome positions for each k-mer
-  std::vector<uint32_t> index_a;  // genome positions for each k-mer
+  std::vector<std::uint32_t> index;    // genome positions for each k-mer
+  std::vector<std::uint32_t> index_t;  // genome positions for each k-mer
+  std::vector<std::uint32_t> index_a;  // genome positions for each k-mer
 
-  std::vector<uint32_t> counter;    // offset of each k-mer in "index"
-  std::vector<uint32_t> counter_t;  // offset of each k-mer in "index"
-  std::vector<uint32_t> counter_a;  // offset of each k-mer in "index"
+  std::vector<std::uint32_t> counter;    // offset of each k-mer in "index"
+  std::vector<std::uint32_t> counter_t;  // offset of each k-mer in "index"
+  std::vector<std::uint32_t> counter_a;  // offset of each k-mer in "index"
 
   // a vector indicating whether each position goes into two-
   // or three-letter encoding
   std::vector<bool> is_two_let;
   std::vector<bool> keep;
-  std::vector<std::pair<size_t, size_t>> exclude{};
+  std::vector<std::pair<std::size_t, std::size_t>> exclude{};
   std::vector<std::pair<genome_four_bit_itr, genome_four_bit_itr>>
     exclude_itr{};
 
@@ -222,7 +223,7 @@ struct AbismalIndex {
 
   // convert the genome to 4-bit encoding
   void
-  encode_genome(const std::vector<uint8_t> &input_genome);
+  encode_genome(const std::vector<std::uint8_t> &input_genome);
 
   // write index to disk
   void
@@ -238,13 +239,13 @@ struct AbismalIndex {
 
 // A/T nucleotide to 1-bit value (0100 | 0001 = 5) is for A or G.
 inline two_letter_t
-get_bit(const uint8_t nt) {
+get_bit(const std::uint8_t nt) {
   return (nt & 5) == 0;
 }
 
 template <const three_conv_type the_conv>
 inline three_letter_t
-get_three_letter_num(const uint8_t nt) {
+get_three_letter_num(const std::uint8_t nt) {
   // the_conv = c_to_t: C=T=0, A=1, G=2
   // the_conv = g_to_a: A=G=0, C=1, T=2
   return the_conv == c_to_t ? (((nt & 4) != 0) << 1) | ((nt & 1) != 0)
@@ -252,13 +253,13 @@ get_three_letter_num(const uint8_t nt) {
 }
 
 inline void
-shift_hash_key(const uint8_t c, uint32_t &hash_key) {
+shift_hash_key(const std::uint8_t c, std::uint32_t &hash_key) {
   hash_key = ((hash_key << 1) | get_bit(c)) & seed::hash_mask;
 }
 
 template <const three_conv_type the_conv>
 inline void
-shift_three_key(const uint8_t c, uint32_t &hash_key) {
+shift_three_key(const std::uint8_t c, std::uint32_t &hash_key) {
   hash_key =
     (hash_key * 3 + get_three_letter_num<the_conv>(c)) % seed::hash_mask_three;
 }
@@ -267,7 +268,7 @@ shift_three_key(const uint8_t c, uint32_t &hash_key) {
 // and the encoding for the function above
 template <class T>
 inline void
-get_1bit_hash(T r, uint32_t &k) {
+get_1bit_hash(T r, std::uint32_t &k) {
   const auto lim = r + seed::key_weight;
   k = 0;
   while (r != lim) {
@@ -278,7 +279,7 @@ get_1bit_hash(T r, uint32_t &k) {
 
 template <const three_conv_type the_conv, class T>
 inline void
-get_base_3_hash(T r, uint32_t &k) {
+get_base_3_hash(T r, std::uint32_t &k) {
   const auto lim = r + seed::key_weight_three;
   k = 0;
   while (r != lim) {


### PR DESCRIPTION
SAM orientation reverse complements reads that map to the negative strand. Original output of abismal has reads in their original format as in the FASTQ files. Now users can choose.